### PR TITLE
Fix: picking start date no longer wipes existing trip days

### DIFF
--- a/agents/create/templates/create.html
+++ b/agents/create/templates/create.html
@@ -327,8 +327,8 @@
         var params = new URLSearchParams(window.location.search);
         var tripLink = params.get('link') || params.get('edit');
     </script>
-    <script src="/static/js/create.js?v=49"></script>
-    <script src="/static/js/create-render.js?v=1"></script>
+    <script src="/static/js/create.js?v=50"></script>
+    <script src="/static/js/create-render.js?v=2"></script>
     <script src="/static/js/create-items.js?v=3"></script>
     <script src="/static/js/create-upload.js?v=3"></script>
     <script src="/static/js/create-save.js?v=3"></script>

--- a/static/js/create-render.js
+++ b/static/js/create-render.js
@@ -28,29 +28,69 @@ function initializeDays() {
 }
 
 /**
- * Update days when dates change
+ * Format a Date as YYYY-MM-DD without UTC rollover.
  */
-function updateDays() {
-    if (currentTrip.start_date && currentTrip.end_date) {
-        // Preserve existing items
-        const existingItems = {};
-        currentTrip.days.forEach(day => {
-            if (day.date) {
-                existingItems[day.date] = day.items;
-            }
-        });
+function _ymd(date) {
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+}
 
-        initializeDays();
+/**
+ * Resize the days array to match start/end dates.
+ *
+ * Returns true if applied, false if the user cancelled a destructive shrink.
+ *
+ * - Map items from old days to new days **by index, not by date** — this
+ *   preserves item ↔ day-number across date shifts (the previous date-key
+ *   match silently lost everything when start_date jumped to a new range).
+ * - If shrinking, dropped days' items move to the Ideas Pile so they're
+ *   recoverable — and we confirm first if any items would be moved.
+ */
+async function updateDays() {
+    if (!currentTrip.start_date || !currentTrip.end_date) return true;
 
-        // Restore items
-        currentTrip.days.forEach(day => {
-            if (existingItems[day.date]) {
-                day.items = existingItems[day.date];
-            }
-        });
+    const start = new Date(currentTrip.start_date + 'T12:00:00');
+    const end = new Date(currentTrip.end_date + 'T12:00:00');
+    if (isNaN(start) || isNaN(end) || end < start) return true;
 
-        renderDays();
+    const newCount = Math.round((end - start) / 86400000) + 1;
+    const oldDays = currentTrip.days || [];
+    const oldCount = oldDays.length;
+
+    // Confirm destructive shrink (only if dropped days have items)
+    if (newCount < oldCount) {
+        const droppedItems = oldDays
+            .slice(newCount)
+            .flatMap(d => d.items || []);
+        if (droppedItems.length > 0) {
+            const ok = await LibertasModal.confirm(
+                `This change will remove ${oldCount - newCount} day${oldCount - newCount === 1 ? '' : 's'} from your trip. ` +
+                `${droppedItems.length} item${droppedItems.length === 1 ? '' : 's'} will be moved to the Ideas Pile so you don't lose ${droppedItems.length === 1 ? 'it' : 'them'}.\n\nContinue?`,
+                { danger: true }
+            );
+            if (!ok) return false;
+            currentTrip.ideas = (currentTrip.ideas || []).concat(droppedItems);
+        }
     }
+
+    // Rebuild days by index — items move with their day_number, not their date
+    const newDays = [];
+    for (let i = 0; i < newCount; i++) {
+        const d = new Date(start);
+        d.setDate(d.getDate() + i);
+        newDays.push({
+            day_number: i + 1,
+            date: _ymd(d),
+            items: oldDays[i]?.items || [],
+        });
+    }
+    currentTrip.days = newDays;
+
+    renderDays();
+    renderIdeas();
+    return true;
 }
 
 /**

--- a/static/js/create.js
+++ b/static/js/create.js
@@ -108,6 +108,17 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 /**
+ * Format a Date as YYYY-MM-DD without UTC rollover.
+ * Mirrors `_ymd` in create-render.js — both files use date math.
+ */
+function _formatYmd(date) {
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
  * Initialize mobile chat sidebar toggle
  */
 function initMobileChatSidebar() {
@@ -189,25 +200,69 @@ function initEventListeners() {
         triggerAutoSave();
     });
 
-    // Editor date changes
-    document.getElementById('editor-start-date')?.addEventListener('change', (e) => {
-        currentTrip.start_date = e.target.value || null;
-        const endDateInput = document.getElementById('editor-end-date');
-        if (e.target.value) {
-            // Set end date minimum to start date
-            endDateInput.min = e.target.value;
-            // If end date is empty or before start date, default to start date
-            if (!endDateInput.value || endDateInput.value < e.target.value) {
-                endDateInput.value = e.target.value;
-                currentTrip.end_date = e.target.value;
-            }
+    // Editor date changes — picking a date should never silently shrink
+    // the trip. If days already exist, shift the other end so the duration
+    // is preserved; if shortening would drop items, updateDays() asks first
+    // and parks them in the Ideas Pile.
+    document.getElementById('editor-start-date')?.addEventListener('change', async (e) => {
+        const newStart = e.target.value || null;
+        const endInput = document.getElementById('editor-end-date');
+        const oldStart = currentTrip.start_date;
+        const oldEnd = currentTrip.end_date;
+        const dayCount = currentTrip.days?.length || 0;
+        const previousStart = oldStart;
+        const previousEnd = oldEnd;
+
+        if (!newStart) {
+            currentTrip.start_date = null;
+            triggerAutoSave();
+            return;
         }
-        updateDays();
+
+        endInput.min = newStart;
+
+        if (oldStart && oldEnd) {
+            // Both dates already set — shift end by the same delta as start
+            const delta = Math.round(
+                (new Date(newStart + 'T12:00:00') - new Date(oldStart + 'T12:00:00')) / 86400000
+            );
+            const newEndD = new Date(oldEnd + 'T12:00:00');
+            newEndD.setDate(newEndD.getDate() + delta);
+            currentTrip.end_date = _formatYmd(newEndD);
+        } else if (dayCount > 1) {
+            // No dates yet but days exist — anchor end at start + (N-1)
+            const newEndD = new Date(newStart + 'T12:00:00');
+            newEndD.setDate(newEndD.getDate() + dayCount - 1);
+            currentTrip.end_date = _formatYmd(newEndD);
+        } else if (!endInput.value || endInput.value < newStart) {
+            // No days, no end yet — fall back to single-day default
+            currentTrip.end_date = newStart;
+        }
+
+        currentTrip.start_date = newStart;
+        endInput.value = currentTrip.end_date || '';
+
+        const ok = await updateDays();
+        if (ok === false) {
+            // User cancelled the shrink — revert
+            currentTrip.start_date = previousStart;
+            currentTrip.end_date = previousEnd;
+            e.target.value = previousStart || '';
+            endInput.value = previousEnd || '';
+            return;
+        }
         triggerAutoSave();
     });
-    document.getElementById('editor-end-date')?.addEventListener('change', (e) => {
-        currentTrip.end_date = e.target.value || null;
-        updateDays();
+    document.getElementById('editor-end-date')?.addEventListener('change', async (e) => {
+        const newEnd = e.target.value || null;
+        const previousEnd = currentTrip.end_date;
+        currentTrip.end_date = newEnd;
+        const ok = await updateDays();
+        if (ok === false) {
+            currentTrip.end_date = previousEnd;
+            e.target.value = previousEnd || '';
+            return;
+        }
         triggerAutoSave();
     });
 


### PR DESCRIPTION
Closes #39

## Summary
- Picking a start date on a multi-day trip used to silently collapse the trip to 1 day and delete every item on days 2..N. Now: shifts end_date to preserve duration; items follow their \`day_number\`, not their date.
- \`updateDays()\` rebuilds the day list **by index**, not by date-key. Earlier code matched items to days by date string, so any date shift dropped them all.
- Added a confirm dialog before any destructive shrink. Items in dropped days are moved to the Ideas Pile so they're recoverable.

## Repro of the original bug (#39)
1. Create a trip, set 7 days
2. Add items to days 2, 3, 5
3. Pick a start date
4. **Old**: trip becomes 1 day, items on days 2–7 silently gone
5. **New**: end_date auto-fills to start + 6, all items still where you put them

## Test plan
- [x] 7-day trip + start-date change preserves duration and items
- [x] End-date earlier than current end with items present → confirm modal appears, items move to Ideas Pile on accept, full revert on cancel
- [x] First-time date set on an N-day trip with no dates yet → end_date = start + (N-1)
- [x] Existing 1-day trip → behavior unchanged
- [x] Full pytest suite (317 passing) + ruff + file-size check

🤖 Generated with [Claude Code](https://claude.com/claude-code)