### PR TITLE
Pre-launch polish + observability + UX safety net

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to Libertas
+
+Thanks for taking a look. Libertas is a personal project I (Amit) use to plan
+my own trips, but I'd love feedback, bug reports, and PRs.
+
+## Easiest ways to help
+
+- **Try it** — [libertas-travel.onrender.com](https://libertas-travel.onrender.com).
+  Email me ([aabtzu@gmail.com](mailto:aabtzu@gmail.com)) for an invite code.
+- **File an issue** for bugs, confusing copy, or missing features:
+  [github.com/aabtzu/libertas-travel/issues](https://github.com/aabtzu/libertas-travel/issues).
+- **Open a PR** — see below.
+
+## Local development
+
+```bash
+git clone https://github.com/aabtzu/libertas-travel.git
+cd libertas-travel
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+export ANTHROPIC_API_KEY=your-key   # required for AI features
+export SECRET_KEY=any-string        # required for Flask sessions
+./dev.sh start                      # runs on http://localhost:8080
+```
+
+Other commands:
+
+```bash
+./dev.sh bg     # start in background, logs at /tmp/libertas.log
+./dev.sh stop
+./dev.sh test   # pytest tests/ -x -q
+```
+
+`AUTH_DISABLED=true` is set automatically by `dev.sh`, which auto-logs you in
+as user 1. To preview the real auth pages, hit `/login` or `/register`
+directly — they're whitelisted in dev mode.
+
+## Pull request guidelines
+
+- **Read [`CLAUDE.md`](CLAUDE.md) first.** It describes the file/folder
+  conventions, code-style rules (ruff), CSS color palette, SQL constants
+  pattern, file-length limits (target 500, hard 800 — enforced in CI), and
+  more. Most "why is this organized like that?" questions are answered there.
+- **Run the checks before pushing:**
+
+  ```bash
+  ruff check . && ruff format --check .
+  python3 scripts/check_file_size.py
+  pytest tests/ -m "not integration" -q
+  ```
+
+  CI runs all three — see `.github/workflows/test.yml`.
+- **One feature/fix per PR.** Smaller is faster to review.
+- **Add a test if you can.** Patterns live in `tests/`. The test suite uses
+  pytest with a Flask test client; conftest.py handles fixtures.
+
+## Things that need help
+
+If you want a starting point, see [open issues](https://github.com/aabtzu/libertas-travel/issues).
+A few I'd particularly welcome help on:
+
+- **Mobile responsive polish** — the create-page editor and explore chat are
+  not great on phones.
+- **Better venue data** — `data/venues_seed.csv` is a starting set; richer
+  curation would meaningfully improve recommendations.
+- **Onboarding flow** — first-time users still see a bit much at once.
+  Suggestions / mockups welcome.
+
+## Code of conduct
+
+Be kind. Assume good faith. If something I do bothers you, tell me.
+
+## License
+
+MIT — see [`LICENSE`](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,9 @@ A few I'd particularly welcome help on:
 - **Onboarding flow** — first-time users still see a bit much at once.
   Suggestions / mockups welcome.
 
-## Be Nice
+## Code of conduct
+
+Be Nice.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,7 @@ A few I'd particularly welcome help on:
 - **Onboarding flow** — first-time users still see a bit much at once.
   Suggestions / mockups welcome.
 
-## Code of conduct
-
-Be kind. Assume good faith. If something I do bothers you, tell me.
+## Be Nice
 
 ## License
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Amit Bhattacharyya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/agents/admin/routes.py
+++ b/agents/admin/routes.py
@@ -18,8 +18,17 @@ OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", Path(__file__).parent.parent.pare
 _SQL_COUNT_USERS = "SELECT COUNT(*) FROM users"
 _SQL_COUNT_TRIPS = "SELECT COUNT(*) FROM trips"
 _SQL_LIST_RECENT_TRIPS = (
-    "SELECT id, user_id, title, link FROM trips ORDER BY created_at DESC LIMIT 10"
+    "SELECT id, user_id, title, link, created_at FROM trips ORDER BY created_at DESC LIMIT 10"
 )
+_SQL_LIST_RECENT_USERS = (
+    "SELECT id, username, email, created_at FROM users ORDER BY created_at DESC LIMIT 10"
+)
+
+
+def _last_24h_clause() -> str:
+    """SQL fragment for "rows created in the last 24 hours". Differs
+    between Postgres and SQLite — keep both variants centralized here."""
+    return "NOW() - INTERVAL '24 hours'" if db.USE_POSTGRES else "datetime('now', '-1 day')"
 
 
 @admin_bp.get("/api/debug")
@@ -75,9 +84,35 @@ def debug():
             debug_info["users_count"] = cursor.fetchone()[0]
             cursor.execute(_SQL_COUNT_TRIPS)
             debug_info["trips_count"] = cursor.fetchone()[0]
+
+            # Usage in the last 24h — quick health check
+            cursor.execute(f"SELECT COUNT(*) FROM users WHERE created_at > {_last_24h_clause()}")
+            debug_info["new_users_24h"] = cursor.fetchone()[0]
+            cursor.execute(f"SELECT COUNT(*) FROM trips WHERE created_at > {_last_24h_clause()}")
+            debug_info["new_trips_24h"] = cursor.fetchone()[0]
+
+            # Recent trips (with timestamps now)
             cursor.execute(_SQL_LIST_RECENT_TRIPS)
             debug_info["trips"] = [
-                {"id": row[0], "user_id": row[1], "title": row[2], "link": row[3]}
+                {
+                    "id": row[0],
+                    "user_id": row[1],
+                    "title": row[2],
+                    "link": row[3],
+                    "created_at": str(row[4]),
+                }
+                for row in cursor.fetchall()
+            ]
+
+            # Recent signups — most useful for monitoring a launch
+            cursor.execute(_SQL_LIST_RECENT_USERS)
+            debug_info["recent_users"] = [
+                {
+                    "id": row[0],
+                    "username": row[1],
+                    "email": row[2],
+                    "created_at": str(row[3]),
+                }
                 for row in cursor.fetchall()
             ]
     except Exception as e:

--- a/agents/admin/routes.py
+++ b/agents/admin/routes.py
@@ -133,7 +133,7 @@ def debug():
                 debug_info["reimport_result"] = "CSV not found"
 
         if request.args.get("geocode_missing"):
-            from geocode_venues import geocode_address
+            from scripts.geocode_venues import geocode_address
 
             venues = load_venues()
             missing = [v for v in venues if not v.get("latitude") or not v.get("longitude")]

--- a/agents/auth/routes.py
+++ b/agents/auth/routes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from flask import Blueprint, request, session
 
 import auth
@@ -48,6 +50,11 @@ def register():
 
     success, error = auth.register_user(username, email, password)
     if success:
+        # Greppable line in Render logs so the owner can monitor signups
+        # via `render logs | grep '\[SIGNUP\]'`. Email/IP intentionally
+        # omitted from logs — keep PII out of the log stream.
+        ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        print(f"[SIGNUP] {username} @ {ts}", flush=True)
         return json_ok({"success": True})
     return json_err(error)
 

--- a/agents/common/templates.py
+++ b/agents/common/templates.py
@@ -63,7 +63,7 @@ FOOTER_HTML = """
             <a href="https://github.com/aabtzu/libertas-travel" target="_blank" rel="noopener">
                 <i class="fab fa-github"></i> GitHub
             </a>
-            <a href="mailto:aabtzu@gmail.com?subject=Libertas%20feedback">
+            <a href="#" onclick="showFeedbackPopup('Libertas feedback'); return false;">
                 <i class="fas fa-envelope"></i> Send feedback
             </a>
         </div>

--- a/agents/common/templates/about.html
+++ b/agents/common/templates/about.html
@@ -6,7 +6,7 @@
     <title>About - Libertas</title>
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/about.css">
 </head>
@@ -59,14 +59,6 @@
             </div>
         </div>
 
-        <div class="quote-box">
-            <blockquote>
-                "The statues of Abeona and Adeona accompanied the statue of Libertas,
-                signifying that freedom could go and return as she wished."
-            </blockquote>
-            <cite>— Marcus Terentius Varro, Antiquitates rerum divinarum</cite>
-        </div>
-
         <div class="about-section">
             <h2><i class="fas fa-robot"></i> What is Libertas?</h2>
             <p>
@@ -94,7 +86,7 @@
                     <i class="fas fa-compass"></i>
                     <div class="feature-text">
                         <h4>Explore Venues</h4>
-                        <p>Discover 2,000+ curated restaurants, hotels, and attractions worldwide</p>
+                        <p>Discover thousands of curated restaurants, hotels, and attractions worldwide</p>
                     </div>
                 </div>
                 <div class="feature">
@@ -132,6 +124,6 @@
 
     {footer_html}
 
-    <script src="/static/js/main.js?v=5"></script>
+    <script src="/static/js/main.js?v=7"></script>
 </body>
 </html>

--- a/agents/common/templates/home.html
+++ b/agents/common/templates/home.html
@@ -6,7 +6,7 @@
     <title>Libertas - Travel Freely</title>
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/home.css">
 </head>
@@ -94,7 +94,7 @@
                     <div class="step-number">2</div>
                     <div class="step-content">
                         <h3>Discover & Refine</h3>
-                        <p>Explore 2,000+ curated venues worldwide. Add restaurants, hotels, and attractions to your trip via chat.</p>
+                        <p>Explore thousands of curated venues worldwide. Add restaurants, hotels, and attractions to your trip via chat.</p>
                     </div>
                 </div>
 
@@ -143,16 +143,8 @@
         </div>
     </div>
 
-    <div class="home-quote">
-        <blockquote>
-            "The statues of Abeona and Adeona accompanied the statue of Libertas,
-            signifying that freedom could go and return as she wished."
-        </blockquote>
-        <cite>— Marcus Terentius Varro</cite>
-    </div>
-
     {footer_html}
 
-    <script src="/static/js/main.js?v=5"></script>
+    <script src="/static/js/main.js?v=7"></script>
 </body>
 </html>

--- a/agents/common/templates/how-it-works.html
+++ b/agents/common/templates/how-it-works.html
@@ -6,7 +6,7 @@
     <title>How It Works - Libertas</title>
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/how-it-works.css?v=2">
 </head>
@@ -145,6 +145,6 @@
 
     {footer_html}
 
-    <script src="/static/js/main.js?v=5"></script>
+    <script src="/static/js/main.js?v=7"></script>
 </body>
 </html>

--- a/agents/common/templates/login.html
+++ b/agents/common/templates/login.html
@@ -6,7 +6,7 @@
     <title>Login - Libertas</title>
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/login.css">
 </head>

--- a/agents/common/templates/register.html
+++ b/agents/common/templates/register.html
@@ -6,7 +6,7 @@
     <title>Register - Libertas</title>
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/login.css">
 </head>
@@ -52,7 +52,8 @@
 
                 <div class="form-group">
                     <label for="invite-code">Invite Code</label>
-                    <input type="password" id="invite-code" name="invite-code" autocomplete="off" placeholder="Required to create an account">
+                    <input type="password" id="invite-code" name="invite-code" autocomplete="off" placeholder="From your invite email">
+                    <p class="form-hint">Don't have a code? <a href="#" onclick="showFeedbackPopup('Libertas invite request'); return false;">Request one</a>.</p>
                 </div>
 
                 <button type="submit" class="login-btn">
@@ -66,6 +67,7 @@
         </div>
     </div>
 
+    <script src="/static/js/main.js?v=7"></script>
     <script src="/static/js/register.js"></script>
 </body>
 </html>

--- a/agents/create/templates/create.html
+++ b/agents/create/templates/create.html
@@ -7,11 +7,11 @@
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/categories.css">
     <link rel="stylesheet" href="/static/css/create.css?v=21">
-    <link rel="stylesheet" href="/static/css/create-content.css?v=1">
+    <link rel="stylesheet" href="/static/css/create-content.css?v=3">
     <link rel="stylesheet" href="/static/css/create-chat.css?v=1">
     <link rel="stylesheet" href="/static/css/create-views.css?v=1">
 </head>
@@ -22,7 +22,7 @@
     <div class="modal-overlay hidden" id="create-dialog">
         <div class="modal-content">
             <h2><i class="fas fa-plane-departure"></i> Create New Trip</h2>
-            <p class="modal-subtitle">Let's plan your adventure!</p>
+            <p class="modal-subtitle">Just a name to start — you can fill in dates and details later.</p>
 
             <form id="create-trip-form">
                 <div class="form-group">
@@ -31,7 +31,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label>Dates <span class="optional">(optional - add later)</span></label>
+                    <label>Dates <span class="optional">(optional — skip if you don't know yet)</span></label>
                     <div class="date-inputs">
                         <div class="date-input-group">
                             <label for="start-date">Start</label>
@@ -51,7 +51,7 @@
                 </div>
 
                 <div class="form-actions">
-                    <a href="/trips.html" class="btn btn-secondary">Cancel</a>
+                    <a href="#" class="btn btn-secondary" id="create-cancel">Cancel</a>
                     <button type="submit" class="btn btn-primary">
                         <i class="fas fa-plus"></i> Create Trip
                     </button>
@@ -80,8 +80,8 @@
                 <button class="btn btn-secondary" id="preview-btn">
                     <i class="fas fa-eye"></i> Preview
                 </button>
-                <button class="btn btn-primary" id="publish-btn">
-                    <i class="fas fa-paper-plane"></i> Publish
+                <button class="btn btn-primary" id="publish-btn" title="Save this trip and add it to My Trips">
+                    <i class="fas fa-paper-plane"></i> Save Trip
                 </button>
             </div>
         </div>
@@ -182,12 +182,41 @@
                     </div>
 
                     <!-- Fill links + Generate write-up -->
-                    <button class="btn-fill-links" id="fill-links-btn">
+                    <div class="trip-tools-hint" id="trip-tools-hint">
+                        <button class="trip-tools-hint-close" id="trip-tools-hint-close" aria-label="Hide this hint" title="Hide — won't show again">&times;</button>
+                        <p class="trip-tools-hint-title"><i class="fas fa-magic"></i> Two AI helpers</p>
+                        <ul class="trip-tools-hint-list">
+                            <li><strong>Fill Missing Links</strong> — finds website + Google Maps URLs for items that don't have them yet.</li>
+                            <li><strong>Generate Write-up</strong> — produces a readable narrative of the trip you can share or paste into an email.</li>
+                        </ul>
+                    </div>
+                    <button class="btn-fill-links" id="fill-links-btn"
+                            title="Use AI to find website + Google Maps URLs for items that are missing them">
                         <i class="fas fa-link"></i> Fill Missing Links
                     </button>
-                    <button class="btn-writeup" id="generate-writeup-btn">
+                    <button class="btn-writeup" id="generate-writeup-btn"
+                            title="Generate an AI-written narrative summary of your trip with links and a map">
                         <i class="fas fa-pen-fancy"></i> Generate Write-up
                     </button>
+                    <script>
+                        // Persistently hide the AI-helpers hint once the user
+                        // has dismissed it. localStorage so the preference
+                        // survives page reloads + new tabs.
+                        (function () {{
+                            var hint = document.getElementById('trip-tools-hint');
+                            var btn = document.getElementById('trip-tools-hint-close');
+                            if (!hint || !btn) return;
+                            try {{
+                                if (localStorage.getItem('libertas_hide_tools_hint') === '1') {{
+                                    hint.style.display = 'none';
+                                }}
+                            }} catch (e) {{ /* private mode etc. */ }}
+                            btn.addEventListener('click', function () {{
+                                hint.style.display = 'none';
+                                try {{ localStorage.setItem('libertas_hide_tools_hint', '1'); }} catch (e) {{}}
+                            }});
+                        }})();
+                    </script>
                     <div class="writeup-result" id="writeup-result" style="display:none">
                         <div class="writeup-header">
                             <span><i class="fas fa-pen-fancy"></i> Write-up</span>
@@ -225,7 +254,7 @@
                         <textarea
                             id="chat-input"
                             class="chat-input"
-                            placeholder="Ask about places, activities..."
+                            placeholder="Try: 'Plan 5 days in Tokyo'"
                             rows="1"
                         ></textarea>
                         <button id="chat-send-btn" class="chat-send-btn">
@@ -320,18 +349,18 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <script src="/static/js/main.js?v=5"></script>
+    <script src="/static/js/main.js?v=7"></script>
     <script src="/static/js/calendar.js?v=2"></script>
     <script>
         // Trip link from URL - check for both 'link' and 'edit' parameters
         var params = new URLSearchParams(window.location.search);
         var tripLink = params.get('link') || params.get('edit');
     </script>
-    <script src="/static/js/create.js?v=50"></script>
+    <script src="/static/js/create.js?v=55"></script>
     <script src="/static/js/create-render.js?v=2"></script>
     <script src="/static/js/create-items.js?v=3"></script>
     <script src="/static/js/create-upload.js?v=3"></script>
-    <script src="/static/js/create-save.js?v=3"></script>
+    <script src="/static/js/create-save.js?v=4"></script>
     <script src="/static/js/create-chat.js?v=1"></script>
     <script src="/static/js/create-dragdrop.js?v=1"></script>
     <script src="/static/js/create-grid.js?v=2"></script>

--- a/agents/explore/static/css/explore-cards-panel.css
+++ b/agents/explore/static/css/explore-cards-panel.css
@@ -585,3 +585,18 @@
     to { transform: rotate(360deg); }
 }
 
+
+/* Note inside the trip-picker explaining where venues go.
+   Solid neutral block (no gradient) so it doesn't compete with the picker. */
+.trip-picker-note {
+    margin: 0 16px 12px;
+    padding: 10px 12px;
+    background: #f5f4ff;
+    color: #444;
+    border-left: 3px solid #667eea;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+.trip-picker-note i { color: #667eea; margin-right: 6px; }
+.trip-picker-note strong { color: #1a1a2e; }

--- a/agents/explore/static/js/explore-trip.js
+++ b/agents/explore/static/js/explore-trip.js
@@ -14,6 +14,10 @@ function showTripPicker(trips, onSelect) {
                 <h3>Add to trip</h3>
                 <button class="trip-picker-close" aria-label="Close"><i class="fas fa-times"></i></button>
             </div>
+            <p class="trip-picker-note">
+                <i class="fas fa-lightbulb"></i>
+                Picks land in your trip's <strong>Ideas Pile</strong> — sort them onto specific days later in the editor.
+            </p>
             <div class="trip-picker-list">
                 <button class="trip-picker-item trip-picker-new" data-action="new">
                     <i class="fas fa-plus-circle"></i>
@@ -39,44 +43,23 @@ function showTripPicker(trips, onSelect) {
         if (!item) return;
 
         if (item.dataset.action === 'new') {
-            // Show inline name input
-            const newBtn = item;
-            newBtn.innerHTML = `
-                <input type="text" class="trip-picker-name-input" placeholder="Trip name..." autofocus>
-                <button class="trip-picker-create-btn"><i class="fas fa-check"></i></button>
-            `;
-            const input = newBtn.querySelector('input');
-            const createBtn = newBtn.querySelector('.trip-picker-create-btn');
-            input.focus();
-
-            const doCreate = async () => {
-                const title = input.value.trim();
-                if (!title) return;
-                try {
-                    const res = await fetch('/api/trips/create', {
-                        method: 'POST',
-                        headers: {'Content-Type': 'application/json'},
-                        body: JSON.stringify({title, trip_type: 'recommendation'}),
-                    });
-                    const data = await res.json();
-                    const link = data.trip?.link || data.link;
-                    if (link) {
-                        // Add to cache
-                        if (_tripsCache) _tripsCache.unshift({link, title, trip_type: 'recommendation'});
-                        overlay.remove();
-                        onSelect(link);
-                    }
-                } catch {}
-            };
-
-            createBtn.addEventListener('click', (ev) => { ev.stopPropagation(); doCreate(); });
-            input.addEventListener('keydown', (ev) => {
-                ev.stopPropagation();
-                if (ev.key === 'Enter') doCreate();
-            });
-            input.addEventListener('click', (ev) => ev.stopPropagation());
-            input.addEventListener('keyup', (ev) => ev.stopPropagation());
-            input.addEventListener('keypress', (ev) => ev.stopPropagation());
+            // Send the user to the full Create Trip dialog (one source of
+            // truth for new-trip creation — name, dates, OR num_days).
+            // Stash the venue + the explore page URL so /create.html can
+            // add the venue once the trip exists and offer a way back.
+            try {
+                if (typeof _pendingVenue !== 'undefined' && _pendingVenue) {
+                    sessionStorage.setItem(
+                        'libertas_pending_venue',
+                        JSON.stringify({
+                            venue: _pendingVenue,
+                            return_to: window.location.pathname + window.location.search,
+                        })
+                    );
+                }
+            } catch { /* sessionStorage may be disabled */ }
+            overlay.remove();
+            window.location.href = '/create.html';
             return;
         }
 
@@ -198,8 +181,13 @@ async function sendToTripWithNote(btn, tripLink, venueData, note) {
     return sendToTrip(btn, tripLink, venueData, note);
 }
 
+// Holds the venue currently being added — accessed by the trip-picker's
+// "New trip" handler to stash for /create.html before redirecting.
+var _pendingVenue = null;  // eslint-disable-line no-unused-vars
+
 async function addToTrip(btn) {
     const venueData = JSON.parse(btn.dataset.venue);
+    _pendingVenue = venueData;
 
     // If a trip is pinned (from explore-trip-panel.js), add directly
     if (typeof _pinnedTrip !== 'undefined' && _pinnedTrip) {

--- a/agents/explore/static/js/explore.js
+++ b/agents/explore/static/js/explore.js
@@ -463,8 +463,8 @@ function createVenueCard(venue) {
                     <button class="venue-action-btn website">
                         <i class="fas fa-globe"></i> Website
                     </button>
-                    <button class="venue-action-btn add-to-trip" data-venue='${JSON.stringify({name: venue.name, city: venue.city, state: venue.state, country: venue.country, venue_type: venue.venue_type, cuisine_type: venue.cuisine_type, latitude: venue.latitude, longitude: venue.longitude, website: venue.website, google_maps_link: venue.google_maps_link}).replace(/'/g, "&#39;")}'>
-                        <i class="fas fa-plus"></i> Trip
+                    <button class="venue-action-btn add-to-trip" data-venue='${JSON.stringify({name: venue.name, city: venue.city, state: venue.state, country: venue.country, venue_type: venue.venue_type, cuisine_type: venue.cuisine_type, latitude: venue.latitude, longitude: venue.longitude, website: venue.website, google_maps_link: venue.google_maps_link}).replace(/'/g, "&#39;")}' title="Add this venue to one of your trips">
+                        <i class="fas fa-plus"></i> Add to trip
                     </button>
                 </div>
             </div>

--- a/agents/explore/templates/explore.html
+++ b/agents/explore/templates/explore.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <style>
 {explore_css}
@@ -124,7 +124,7 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <script src="/static/js/main.js?v=6"></script>
+    <script src="/static/js/main.js?v=7"></script>
     <script>
 {explore_js}
     </script>

--- a/agents/itinerary/templates.py
+++ b/agents/itinerary/templates.py
@@ -299,7 +299,9 @@ def generate_trip_card(
     )
     public_class = "active" if is_public else ""
     public_icon = "globe" if is_public else "lock"
-    public_title = "Make private" if is_public else "Make public"
+    public_title = (
+        "Public link — click to make private" if is_public else "Private — click to share via link"
+    )
 
     # Draft settings - drafts link to create/edit page
     draft_badge = (

--- a/agents/itinerary/templates/trip.html
+++ b/agents/itinerary/templates/trip.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/trip.css?v=10">
     <link rel="stylesheet" href="/static/css/trip-calendar.css?v=1">
@@ -96,7 +96,7 @@
     <script>var mapData = {map_data_json};</script>
     <script>var tripViewerContext = {{ isOwner: {is_owner_json}, isAuthenticated: {is_authenticated_json} }};</script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-    <script src="/static/js/main.js?v=5"></script>
+    <script src="/static/js/main.js?v=7"></script>
     <script src="/static/js/calendar.js?v=2"></script>
     <script src="/static/js/item-detail.js?v=1"></script>
     <script src="/static/js/trip.js?v=11"></script>

--- a/agents/itinerary/templates/trips.html
+++ b/agents/itinerary/templates/trips.html
@@ -7,10 +7,10 @@
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/categories.css">
-    <link rel="stylesheet" href="/static/css/trips.css?v=11">
+    <link rel="stylesheet" href="/static/css/trips.css?v=12">
     <link rel="stylesheet" href="/static/css/trips-actions.css?v=1">
     <link rel="stylesheet" href="/static/css/trips-share-map.css?v=1">
 </head>
@@ -27,6 +27,20 @@
                 <i class="fas fa-plus"></i> New Trip
             </a>
         </div>
+    </div>
+
+    <!-- First-time intro card. Shown once per browser, hidden on dismiss
+         or after the user adds their first trip. -->
+    <div class="trips-intro" id="trips-intro" hidden>
+        <button class="trips-intro-close" id="trips-intro-close" aria-label="Dismiss">&times;</button>
+        <h3><i class="fas fa-hand-sparkles"></i> Welcome to Libertas</h3>
+        <p>Your trips live here. Three quick ways to get started:</p>
+        <ul>
+            <li><strong>Drop a PDF or .ics</strong> into the import box below — confirmations from airlines and hotels work.</li>
+            <li><strong>Paste a Google Maps directions link</strong> to import a route with stops.</li>
+            <li><strong>Create from scratch</strong> with the AI co-planner.</li>
+        </ul>
+        <button class="trips-intro-got-it" id="trips-intro-got-it">Got it</button>
     </div>
 
     <div class="trips-container">
@@ -136,9 +150,9 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <script src="/static/js/main.js?v=5"></script>
+    <script src="/static/js/main.js?v=7"></script>
     <script src="/static/js/archive.js?v=1"></script>
-    <script src="/static/js/upload.js?v=8"></script>
-    <script src="/static/js/trips.js?v=7"></script>
+    <script src="/static/js/upload.js?v=9"></script>
+    <script src="/static/js/trips.js?v=8"></script>
 </body>
 </html>

--- a/agents/pages/profile_view.py
+++ b/agents/pages/profile_view.py
@@ -44,7 +44,7 @@ def generate_profile_page(profile_data: dict[str, Any]) -> str:
     <title>Profile - Libertas</title>
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <style>
         .profile-hero {{

--- a/agents/pages/recommendation_view.py
+++ b/agents/pages/recommendation_view.py
@@ -177,7 +177,7 @@ def generate_recommendation_page(
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <style>
         .rec-hero {{
@@ -405,7 +405,7 @@ def render_writeup_page(
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
-    <link rel="stylesheet" href="/static/css/main.css?v=11">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <style>
         .writeup-hero {{

--- a/agents/pages/routes.py
+++ b/agents/pages/routes.py
@@ -55,7 +55,10 @@ def explore():
 @pages_bp.get("/login")
 @pages_bp.get("/login.html")
 def login():
-    if g.user_id:
+    # In dev (AUTH_DISABLED=true) every request gets a fake user_id, which
+    # would otherwise redirect away from the auth pages and make them
+    # unreachable for previewing.
+    if g.user_id and not g.auth_disabled:
         return redirect("/")
     return _html(generate_login_page())
 
@@ -63,7 +66,7 @@ def login():
 @pages_bp.get("/register")
 @pages_bp.get("/register.html")
 def register():
-    if g.user_id:
+    if g.user_id and not g.auth_disabled:
         return redirect("/")
     return _html(generate_register_page())
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,7 @@
+"""Standalone scripts and importable helpers.
+
+Anything runnable as `python3 scripts/<name>.py` lives here. A few of these
+also expose pure functions imported by application code (e.g.
+`geocode_address` in `geocode_venues.py`), which is why this directory is
+a real package rather than a flat folder.
+"""

--- a/scripts/geocode_venues.py
+++ b/scripts/geocode_venues.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
-"""Geocode venues missing lat/lng coordinates using OpenStreetMap Nominatim (free)."""
+"""Geocode venues missing lat/lng coordinates using OpenStreetMap Nominatim (free).
+
+Importable: `geocode_address()` is a pure stdlib helper used by the admin
+route at `agents/admin/routes.py`. Runnable: `python3 scripts/geocode_venues.py`
+walks the venue table and fills in missing lat/lng.
+"""
 
 import json
+import os
 import ssl
+import sys
 import time
 import urllib.parse
 import urllib.request
+
+# Add project root to sys.path so `import database` works when this script
+# is run directly (e.g. `python3 scripts/geocode_venues.py`).
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 
 def geocode_address(name: str, city: str, country: str) -> tuple:

--- a/scripts/import_venues.py
+++ b/scripts/import_venues.py
@@ -4,16 +4,16 @@
 import os
 import sys
 
-# Add parent directory to path for imports
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# Add the project root (parent of scripts/) to sys.path so `from database`
+# resolves when this file is run directly.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _REPO_ROOT)
 
-from database import get_venue_count, import_venues_from_csv
+from database import get_venue_count, import_venues_from_csv  # noqa: E402
 
 
 def main():
-    # Get path to seed data
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    csv_path = os.path.join(script_dir, "data", "venues_seed.csv")
+    csv_path = os.path.join(_REPO_ROOT, "data", "venues_seed.csv")
 
     if not os.path.exists(csv_path):
         print(f"Error: Seed data not found at {csv_path}")

--- a/scripts/launch-stats.sh
+++ b/scripts/launch-stats.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# launch-stats.sh — quick health + usage report for the prod app.
+#
+# Reads SECRET_KEY from the env (export it before running) and hits
+# /api/debug on the production app. Pipes through jq for a friendly
+# summary.
+#
+# Usage:
+#   export SECRET_KEY='<the-X-Admin-Key-from-Render>'
+#   ./scripts/launch-stats.sh
+#   ./scripts/launch-stats.sh --raw       # full JSON dump
+#   ./scripts/launch-stats.sh --staging   # use a different host
+#
+# Requires: curl, jq.
+
+set -euo pipefail
+
+HOST="${LIBERTAS_HOST:-https://libertas-travel.onrender.com}"
+RAW=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --raw)     RAW=1 ;;
+    --staging) HOST="https://libertas-travel-staging.onrender.com" ;;
+    --host=*)  HOST="${arg#--host=}" ;;
+    -h|--help)
+      sed -n '2,16p' "$0"
+      exit 0 ;;
+    *)
+      echo "Unknown arg: $arg" >&2
+      exit 1 ;;
+  esac
+done
+
+if [ -z "${SECRET_KEY:-}" ]; then
+  echo "ERROR: SECRET_KEY is not set." >&2
+  echo "  export SECRET_KEY='<your X-Admin-Key from Render dashboard>'" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required (brew install jq)." >&2
+  exit 1
+fi
+
+resp=$(curl -fsS -H "X-Admin-Key: $SECRET_KEY" "$HOST/api/debug" || true)
+
+if [ -z "$resp" ]; then
+  echo "ERROR: empty response from $HOST/api/debug — check the host and SECRET_KEY." >&2
+  exit 1
+fi
+
+if [ "$RAW" -eq 1 ]; then
+  echo "$resp" | jq .
+  exit 0
+fi
+
+echo "$resp" | jq -r '
+  "=== Libertas — \(.cwd // "prod") ===",
+  "",
+  "Totals:",
+  "  Users:  \(.users_count // "?")",
+  "  Trips:  \(.trips_count // "?")",
+  "  Venues: \(.venue_count // "?")",
+  "",
+  "Last 24 hours:",
+  "  New users: \(.new_users_24h // 0)",
+  "  New trips: \(.new_trips_24h // 0)",
+  "",
+  "Recent signups:",
+  (.recent_users // [] | if length == 0 then "  (none)" else
+    map("  • \(.username)  (\(.email))  \(.created_at)")[]
+  end),
+  "",
+  "Recent trips:",
+  (.trips // [] | if length == 0 then "  (none)" else
+    map("  • [user \(.user_id)] \(.title)  →  /\(.link)  \(.created_at)")[]
+  end),
+  ""
+'

--- a/static/css/create-content.css
+++ b/static/css/create-content.css
@@ -363,3 +363,46 @@
     animation: spin 1s linear infinite;
 }
 
+
+/* Explainer above the AI helper buttons (Fill Links / Generate Write-up).
+   Dismissible — once the user knows what they do, the X hides it for good
+   (libertas_hide_tools_hint in localStorage). */
+.trip-tools-hint {
+    position: relative;
+    margin: 18px 0 12px;
+    padding: 14px 36px 12px 16px;
+    background: #f0f1ff;
+    border: 1px solid #c7c9f7;
+    border-left: 4px solid #667eea;
+    border-radius: 8px;
+    color: #1a1a2e;
+    font-size: 0.88rem;
+    line-height: 1.5;
+}
+.trip-tools-hint-title {
+    margin: 0 0 6px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: #1a1a2e;
+}
+.trip-tools-hint-title i { color: #667eea; margin-right: 6px; }
+.trip-tools-hint-list {
+    margin: 0;
+    padding-left: 20px;
+}
+.trip-tools-hint-list li { margin-bottom: 4px; }
+.trip-tools-hint-list li:last-child { margin-bottom: 0; }
+.trip-tools-hint-list strong { color: #4a5fd6; }
+.trip-tools-hint-close {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    background: transparent;
+    border: none;
+    color: #888a96;
+    font-size: 1.3rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px 8px;
+}
+.trip-tools-hint-close:hover { color: #1a1a2e; }

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -74,6 +74,14 @@
     box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
 }
 
+.form-hint {
+    margin: 4px 0 0;
+    font-size: 0.8rem;
+    color: #666;
+}
+.form-hint a { color: #667eea; }
+.form-hint a:hover { text-decoration: underline; }
+
 .login-btn {
     background: #667eea;
     color: white;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -547,3 +547,170 @@ body {
     background: #667eea;
     color: white;
 }
+
+/* ==================== Generic fast tooltip ==================== */
+/* Native title="" tooltips have a ~1s delay. This shows the same text
+   as a small dark bubble below any element with a `data-tip` attribute
+   or a `.has-tip` class plus `title=""`, with no delay. Faster than the
+   browser default and consistent with our trip-card action buttons. */
+[data-tip],
+.btn[title]:not([data-tip]),
+.has-tip[title] {
+    position: relative;
+}
+[data-tip]::after,
+.btn[title]:not([data-tip])::after,
+.has-tip[title]::after {
+    content: attr(title);
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: #1a1a2e;
+    color: white;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 0.78rem;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease 0.2s;
+    z-index: 100;
+}
+[data-tip]:hover::after,
+.btn[title]:not([data-tip]):hover::after,
+.has-tip[title]:hover::after {
+    opacity: 1;
+}
+/* For tooltips on data-tip, pull the value from data-tip instead of title */
+[data-tip]::after { content: attr(data-tip); }
+
+/* Post-Explore banner: shown on /create.html after auto-adding a venue
+   from the Explore → New Trip flow. Solid color, no gradient. */
+.post-explore-banner {
+    position: fixed;
+    top: 70px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1500;
+    background: #1a1a2e;
+    color: white;
+    padding: 10px 18px;
+    border-radius: 10px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+    max-width: 560px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    opacity: 1;
+    transition: opacity 0.6s ease;
+}
+.post-explore-banner i { color: #43a047; margin-right: 6px; }
+.post-explore-banner strong { color: #f0c674; }
+.post-explore-banner .post-explore-back {
+    display: inline-block;
+    margin-left: 10px;
+    color: #cfd2dc;
+    text-decoration: underline;
+}
+.post-explore-banner .post-explore-back:hover { color: #fff; }
+.post-explore-banner.fading { opacity: 0; }
+
+/* Feedback popup — used by the footer "Send feedback" link and the
+   register-page "Email Amit" link. Self-contained: shows the email,
+   offers a Copy button, and links to Gmail/Outlook web + mailto. */
+.feedback-popup-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+    padding: 16px;
+}
+.feedback-popup {
+    background: white;
+    color: #1a1a2e;
+    padding: 28px 24px 24px;
+    border-radius: 14px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3);
+    width: 100%;
+    max-width: 420px;
+    position: relative;
+}
+.feedback-popup h3 {
+    margin: 0 0 14px;
+    font-size: 1.2rem;
+}
+.feedback-popup-body { margin: 0 0 8px; color: #555; }
+.feedback-popup-email {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: #f5f4ff;
+    border: 1px solid #e0dfff;
+    border-radius: 8px;
+    padding: 8px 10px;
+    margin-bottom: 14px;
+}
+.feedback-popup-email code {
+    flex: 1;
+    font-size: 0.95rem;
+    background: transparent;
+    color: #1a1a2e;
+    word-break: break-all;
+}
+.feedback-popup-copy {
+    background: #667eea;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 10px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    white-space: nowrap;
+}
+.feedback-popup-copy:hover { background: #5a6fd6; }
+.feedback-popup-hint { margin: 0 0 8px; color: #666; font-size: 0.85rem; }
+.feedback-popup-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+.feedback-popup-btn {
+    flex: 1 1 auto;
+    background: white;
+    color: #667eea;
+    border: 1px solid #667eea;
+    border-radius: 8px;
+    padding: 8px 12px;
+    text-decoration: none;
+    text-align: center;
+    font-size: 0.85rem;
+    min-width: 110px;
+}
+.feedback-popup-btn:hover {
+    background: #667eea;
+    color: white;
+}
+.feedback-popup-btn-secondary {
+    color: #666;
+    border-color: #ccc;
+}
+.feedback-popup-btn-secondary:hover {
+    background: #444;
+    color: white;
+    border-color: #444;
+}
+.feedback-popup-close {
+    position: absolute;
+    top: 8px;
+    right: 12px;
+    background: transparent;
+    border: none;
+    color: #888;
+    font-size: 1.5rem;
+    cursor: pointer;
+    line-height: 1;
+}
+.feedback-popup-close:hover { color: #1a1a2e; }

--- a/static/css/trips.css
+++ b/static/css/trips.css
@@ -407,3 +407,52 @@
     margin-bottom: 10px;
 }
 
+
+/* First-time intro card on /trips. Solid color block, dismissible. */
+.trips-intro {
+    position: relative;
+    margin: 16px 24px 0;
+    padding: 18px 44px 18px 22px;
+    background: #f0f1ff;
+    border: 1px solid #c7c9f7;
+    border-left: 4px solid #667eea;
+    border-radius: 10px;
+    color: #1a1a2e;
+    box-shadow: 0 2px 8px rgba(102, 126, 234, 0.08);
+}
+.trips-intro h3 {
+    margin: 0 0 8px;
+    font-size: 1.05rem;
+    color: #1a1a2e;
+}
+.trips-intro h3 i { color: #f0c674; margin-right: 6px; }
+.trips-intro p { margin: 0 0 8px; color: #444; }
+.trips-intro ul {
+    margin: 0 0 14px;
+    padding-left: 22px;
+    color: #444;
+    line-height: 1.5;
+}
+.trips-intro ul strong { color: #4a5fd6; }
+.trips-intro-got-it {
+    background: #667eea;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 18px;
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+.trips-intro-got-it:hover { background: #5a6fd6; }
+.trips-intro-close {
+    position: absolute;
+    top: 10px;
+    right: 14px;
+    background: transparent;
+    border: none;
+    color: #888a96;
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+}
+.trips-intro-close:hover { color: #1a1a2e; }

--- a/static/js/create-save.js
+++ b/static/js/create-save.js
@@ -89,8 +89,8 @@ async function publishTrip() {
 
     const isRepublish = !currentTrip.is_draft;
     const confirmMsg = isRepublish
-        ? 'Republish this trip? This will regenerate the trip page with your latest changes.'
-        : 'Publish this trip? It will be visible in your trips list.';
+        ? 'Update the trip page with your latest changes?'
+        : 'Save this trip? It will be added to your My Trips list.';
 
     const confirmed = await LibertasModal.confirm(confirmMsg);
     if (!confirmed) return;
@@ -107,7 +107,7 @@ async function publishTrip() {
         const data = await response.json();
 
         if (data.success) {
-            const successMsg = isRepublish ? 'Trip republished successfully!' : 'Trip published successfully!';
+            const successMsg = isRepublish ? 'Trip updated!' : 'Trip saved! It\'s in your My Trips list now.';
             await LibertasModal.alert(successMsg);
             if (isRepublish) {
                 // For republish, open the trip view to see changes

--- a/static/js/create.js
+++ b/static/js/create.js
@@ -108,6 +108,98 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 /**
+ * If the user got here from Explore's "Add to trip → New trip" flow, the
+ * venue they wanted to add is stashed in sessionStorage. Attach it to the
+ * freshly-created trip and reload the editor so the user sees it in the
+ * ideas list. A small banner offers a one-click way back to Explore.
+ */
+async function _maybeAttachPendingVenue(tripLink) {
+    let stash;
+    try {
+        const raw = sessionStorage.getItem('libertas_pending_venue');
+        if (!raw) return;
+        sessionStorage.removeItem('libertas_pending_venue');
+        stash = JSON.parse(raw);
+    } catch {
+        return;
+    }
+    if (!stash || !stash.venue || !tripLink) return;
+
+    const venue = stash.venue;
+    const location = [venue.city, venue.state, venue.country].filter(Boolean).join(', ');
+    let mapsLink = venue.google_maps_link || '';
+    if (!mapsLink && venue.latitude && venue.longitude) {
+        mapsLink = `https://www.google.com/maps/search/?api=1&query=${venue.latitude},${venue.longitude}`;
+    } else if (!mapsLink) {
+        const q = encodeURIComponent(`${venue.name} ${location}`);
+        mapsLink = `https://www.google.com/maps/search/?api=1&query=${q}`;
+    }
+    const item = {
+        title: venue.name,
+        category: venue.venue_type === 'Restaurant' || venue.venue_type === 'Cafe' ? 'meal' : 'activity',
+        location,
+        latitude: venue.latitude || null,
+        longitude: venue.longitude || null,
+        notes: venue.cuisine_type || '',
+        website: venue.website || '',
+        google_maps_link: mapsLink,
+    };
+
+    let added = false;
+    try {
+        const res = await fetch(`/api/trips/${encodeURIComponent(tripLink)}/items`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({item}),
+        });
+        added = res.ok;
+    } catch { /* swallow */ }
+
+    if (!added) return;
+
+    // Refresh the editor view so the venue shows up in the ideas list right
+    // away. Push the item into local state and re-render — avoids a full
+    // page reload that would lose the URL.
+    if (typeof currentTrip !== 'undefined' && currentTrip) {
+        currentTrip.ideas = currentTrip.ideas || [];
+        currentTrip.ideas.push(item);
+        if (typeof renderIdeas === 'function') renderIdeas();
+    }
+
+    _showPostExploreBanner(venue.name, stash.return_to);
+}
+
+/**
+ * Banner shown after a venue is auto-attached to a freshly-created trip
+ * via the Explore → New Trip flow. Lets the user jump back to Explore
+ * with one click instead of guessing the URL.
+ */
+function _showPostExploreBanner(venueName, returnTo) {
+    if (document.getElementById('post-explore-banner')) return;
+    const banner = document.createElement('div');
+    banner.id = 'post-explore-banner';
+    banner.className = 'post-explore-banner';
+    const safeName = (venueName || 'venue').replace(/</g, '&lt;');
+    const back = (returnTo && typeof returnTo === 'string') ? returnTo : '/explore.html';
+    banner.innerHTML = (
+        '<i class="fas fa-check-circle"></i> ' +
+        `<strong>${safeName}</strong> is in your <strong>Ideas Pile</strong> below. ` +
+        `<a href="${back}" class="post-explore-back">← Back to Explore for more</a>`
+    );
+    document.body.appendChild(banner);
+    // Click anywhere on the banner (except the back link) to dismiss
+    banner.addEventListener('click', (e) => {
+        if (e.target.closest('.post-explore-back')) return;
+        banner.remove();
+    });
+    // Auto-dismiss after 8s — long enough to read, short enough to not nag
+    setTimeout(() => {
+        if (banner.parentNode) banner.classList.add('fading');
+    }, 8000);
+    setTimeout(() => banner.remove(), 9000);
+}
+
+/**
  * Format a Date as YYYY-MM-DD without UTC rollover.
  * Mirrors `_ymd` in create-render.js — both files use date math.
  */
@@ -171,6 +263,17 @@ function initEventListeners() {
     const createForm = document.getElementById('create-trip-form');
     if (createForm) {
         createForm.addEventListener('submit', handleCreateTrip);
+    }
+
+    // Cancel button — also clears any stashed Explore venue so it doesn't
+    // attach to a different trip the user creates later.
+    const cancelBtn = document.getElementById('create-cancel');
+    if (cancelBtn) {
+        cancelBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            try { sessionStorage.removeItem('libertas_pending_venue'); } catch (e2) {}
+            window.location.href = '/trips.html';
+        });
     }
 
     // Date field interactions (clear num_days when dates are set)
@@ -394,6 +497,11 @@ async function handleCreateTrip(e) {
             updateEditorUI();
             hideCreateDialog();
             showWelcomeMessage();
+
+            // If the user came from Explore via "Add to trip → New trip",
+            // attach the stashed venue and bounce them back to where they
+            // were exploring. Saves the user from re-finding the venue.
+            await _maybeAttachPendingVenue(currentTrip.link);
         } else {
             LibertasModal.alert(data.error || 'Failed to create trip');
         }
@@ -451,15 +559,18 @@ async function loadTrip(link) {
             updateEditorUI();
             hideCreateDialog();
 
-            // Change publish button text for already-published trips
+            // Button label depends on draft status. New trips are drafts;
+            // saving promotes them to the My Trips list. Existing trips
+            // already live in the list, so the button just regenerates the
+            // viewable HTML with the latest edits.
             const publishBtn = document.getElementById('publish-btn');
             if (publishBtn) {
                 if (!trip.is_draft) {
-                    publishBtn.innerHTML = '<i class="fas fa-sync-alt"></i> Republish';
-                    publishBtn.title = 'Regenerate trip HTML with latest changes';
+                    publishBtn.innerHTML = '<i class="fas fa-sync-alt"></i> Save Changes';
+                    publishBtn.title = 'Update the trip page with your latest edits';
                 } else {
-                    publishBtn.innerHTML = '<i class="fas fa-paper-plane"></i> Publish';
-                    publishBtn.title = '';
+                    publishBtn.innerHTML = '<i class="fas fa-paper-plane"></i> Save Trip';
+                    publishBtn.title = 'Save this trip and add it to My Trips';
                 }
             }
 

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -33,9 +33,13 @@ document.getElementById('login-form').addEventListener('submit', async function(
                     console.log('Password credential storage skipped:', credErr);
                 }
             }
-            // Redirect to the original page or home
-            const redirect = new URLSearchParams(window.location.search).get('redirect') || '/';
-            window.location.href = redirect;
+            // Redirect to the original page or home — but only if the
+            // redirect param is a same-origin path. An attacker linking to
+            // /login?redirect=https://evil.com would otherwise send the
+            // user offsite right after they entered their password.
+            const raw = new URLSearchParams(window.location.search).get('redirect') || '/';
+            const safe = raw.startsWith('/') && !raw.startsWith('//') ? raw : '/';
+            window.location.href = safe;
         } else {
             errorMsg.textContent = data.error || 'Invalid username or password';
             errorDiv.classList.add('show');

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -625,3 +625,96 @@ document.addEventListener('DOMContentLoaded', function() {
 
     console.log('Libertas loaded');
 });
+
+/**
+ * Feedback / invite-request popup. Replaces the mailto: link in the footer
+ * (and similar) — most users don't have a mail client configured, so a
+ * mailto link silently fails. This pops a small modal with:
+ *   - The email shown visibly so anyone can copy it manually
+ *   - A one-click Copy button (uses navigator.clipboard with fallback)
+ *   - Quick-open links for Gmail and Outlook web compose
+ *   - A mailto: link for users with a default mail app
+ */
+window.showFeedbackPopup = function (subject) {
+    const email = 'aabtzu@gmail.com';
+    const subj = subject || 'Libertas feedback';
+    const subjEnc = encodeURIComponent(subj);
+
+    // Build modal
+    const overlay = document.createElement('div');
+    overlay.className = 'feedback-popup-overlay';
+    overlay.innerHTML = `
+        <div class="feedback-popup">
+            <button class="feedback-popup-close" aria-label="Close">&times;</button>
+            <h3>Send feedback</h3>
+            <p class="feedback-popup-body">Reach Amit at:</p>
+            <div class="feedback-popup-email">
+                <code>${email}</code>
+                <button class="feedback-popup-copy" type="button">
+                    <i class="fas fa-copy"></i> Copy
+                </button>
+            </div>
+            <p class="feedback-popup-hint">Or open compose in:</p>
+            <div class="feedback-popup-links">
+                <a class="feedback-popup-btn"
+                   href="https://mail.google.com/mail/?view=cm&fs=1&to=${email}&su=${subjEnc}"
+                   target="_blank" rel="noopener">
+                   <i class="fab fa-google"></i> Gmail
+                </a>
+                <a class="feedback-popup-btn"
+                   href="https://outlook.live.com/mail/0/deeplink/compose?to=${email}&subject=${subjEnc}"
+                   target="_blank" rel="noopener">
+                   <i class="fas fa-envelope"></i> Outlook
+                </a>
+                <a class="feedback-popup-btn feedback-popup-btn-secondary"
+                   href="mailto:${email}?subject=${subjEnc}">
+                   <i class="fas fa-paper-plane"></i> Default mail app
+                </a>
+            </div>
+        </div>
+    `;
+    document.body.appendChild(overlay);
+
+    // Wire close handlers
+    const close = () => overlay.remove();
+    overlay.addEventListener('click', (e) => {
+        if (e.target === overlay || e.target.closest('.feedback-popup-close')) {
+            close();
+        }
+    });
+    const onEsc = (e) => {
+        if (e.key === 'Escape') {
+            close();
+            document.removeEventListener('keydown', onEsc);
+        }
+    };
+    document.addEventListener('keydown', onEsc);
+
+    // Wire copy button
+    const copyBtn = overlay.querySelector('.feedback-popup-copy');
+    copyBtn.addEventListener('click', async () => {
+        let copied = false;
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(email);
+                copied = true;
+            }
+        } catch { /* fall through */ }
+        if (!copied) {
+            // Fallback: select an off-screen textarea
+            const ta = document.createElement('textarea');
+            ta.value = email;
+            ta.style.cssText = 'position:fixed;opacity:0;';
+            document.body.appendChild(ta);
+            ta.select();
+            try { document.execCommand('copy'); copied = true; } catch {}
+            document.body.removeChild(ta);
+        }
+        if (copied) {
+            copyBtn.innerHTML = '<i class="fas fa-check"></i> Copied!';
+            setTimeout(() => {
+                copyBtn.innerHTML = '<i class="fas fa-copy"></i> Copy';
+            }, 1800);
+        }
+    });
+};

--- a/static/js/trips.js
+++ b/static/js/trips.js
@@ -337,6 +337,36 @@ async function fetchAndApply(link) {
 }
 
 // Initialize on page load
+/**
+ * First-time intro card on /trips. Shown once per browser, then hidden
+ * forever (libertas_seen_trips_intro in localStorage). Skipped entirely
+ * for users who already have at least one trip — they don't need it.
+ */
+function maybeShowTripsIntro() {
+    const intro = document.getElementById('trips-intro');
+    if (!intro) return;
+    let seen = false;
+    try {
+        seen = localStorage.getItem('libertas_seen_trips_intro') === '1';
+    } catch (e) { /* private mode etc. */ }
+    if (seen) return;
+
+    // Skip if the user already has trips — they don't need a tutorial
+    const hasTrips = document.querySelectorAll('#trips-container .trip-card-wrapper').length > 0;
+    if (hasTrips) {
+        try { localStorage.setItem('libertas_seen_trips_intro', '1'); } catch (e) {}
+        return;
+    }
+
+    intro.removeAttribute('hidden');
+    const dismiss = () => {
+        intro.setAttribute('hidden', '');
+        try { localStorage.setItem('libertas_seen_trips_intro', '1'); } catch (e) {}
+    };
+    document.getElementById('trips-intro-close')?.addEventListener('click', dismiss);
+    document.getElementById('trips-intro-got-it')?.addEventListener('click', dismiss);
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     // Check for URL hash to switch views
     const hash = window.location.hash.slice(1);
@@ -344,4 +374,5 @@ document.addEventListener('DOMContentLoaded', function() {
         switchTripsView(hash);
     }
     loadCardIcons();
+    maybeShowTripsIntro();
 });

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -188,7 +188,9 @@ function handleUrlImport(url) {
  * Prompt user for trip name after import using a custom modal
  */
 function promptForTripName(suggestedName, link) {
-    // Create modal overlay
+    // Build modal via DOM (not innerHTML) so an attacker-controlled
+    // suggestedName from a parsed file can't break out of the value="..."
+    // attribute and inject markup.
     const overlay = document.createElement('div');
     overlay.className = 'modal-overlay';
     overlay.innerHTML = `
@@ -199,7 +201,7 @@ function promptForTripName(suggestedName, link) {
             </div>
             <div class="modal-body">
                 <p>Suggested name based on destination:</p>
-                <input type="text" class="modal-input" id="trip-name-input" value="${suggestedName}">
+                <input type="text" class="modal-input" id="trip-name-input">
             </div>
             <div class="modal-footer">
                 <button class="modal-btn modal-btn-secondary" id="modal-cancel">Use Suggested</button>
@@ -209,8 +211,9 @@ function promptForTripName(suggestedName, link) {
     `;
     document.body.appendChild(overlay);
 
-    // Focus input and select all text
+    // Set the input value via DOM property — safe regardless of contents
     const input = document.getElementById('trip-name-input');
+    input.value = suggestedName || '';
     input.focus();
     input.select();
 
@@ -436,17 +439,31 @@ function openShareModal(link, title) {
 
     modal.classList.add('show');
 
-    // Load users
+    // Load users — build via DOM (no innerHTML interpolation) so a
+    // username with quotes / `<script>` can't break out and inject code.
     fetch('/api/users', { method: 'POST' })
         .then(response => response.json())
         .then(data => {
+            userList.innerHTML = '';
             if (data.success && data.users.length > 0) {
-                userList.innerHTML = data.users.map(user => `
-                    <div class="user-item" onclick="shareWithUser(${user.id}, '${user.username}')">
-                        <i class="fas fa-user"></i>
-                        <span class="username">${user.username}</span>
-                    </div>
-                `).join('');
+                data.users.forEach(user => {
+                    const item = document.createElement('div');
+                    item.className = 'user-item';
+                    item.dataset.userId = user.id;
+                    item.dataset.username = user.username;
+                    item.addEventListener('click', () => {
+                        shareWithUser(user.id, user.username);
+                    });
+                    const icon = document.createElement('i');
+                    icon.className = 'fas fa-user';
+                    const nameSpan = document.createElement('span');
+                    nameSpan.className = 'username';
+                    nameSpan.textContent = user.username;  // safe
+                    item.appendChild(icon);
+                    item.appendChild(document.createTextNode(' '));
+                    item.appendChild(nameSpan);
+                    userList.appendChild(item);
+                });
             } else {
                 userList.innerHTML = '<div class="loading">No other users available</div>';
             }
@@ -573,7 +590,7 @@ function _ensurePublicThenCopy(buildUrl) {
                 if (publicBtn) {
                     publicBtn.dataset.public = 'true';
                     publicBtn.classList.add('active');
-                    publicBtn.title = 'Make private';
+                    publicBtn.title = 'Public link — click to make private';
                     publicBtn.innerHTML = '<i class="fas fa-globe"></i>';
                 }
                 doCopy();
@@ -626,7 +643,9 @@ function togglePublic(btn) {
             // Update button state
             btn.dataset.public = newPublicState ? 'true' : 'false';
             btn.classList.toggle('active', newPublicState);
-            btn.title = newPublicState ? 'Make private' : 'Make public';
+            btn.title = newPublicState
+                ? 'Public link — click to make private'
+                : 'Private — click to share via link';
             btn.innerHTML = newPublicState ? '<i class="fas fa-globe"></i>' : '<i class="fas fa-lock"></i>';
 
             // Update public badge (positioned at top-left of wrapper)


### PR DESCRIPTION
Closes #41 (most of), plus a handful of audit-found bugs. Friends-launch is tomorrow — this is the batch I want shipped before the email goes out.

## TL;DR
- Sharper landing copy, cleaner empty-states, real onboarding cues
- Send-feedback popup that actually works without a configured mail client
- Explore → New Trip flow now uses the full Create dialog with safe stash/banner
- Two real XSS fixes + an open-redirect fix
- /api/debug now returns recent-signups + 24h activity; new \`scripts/launch-stats.sh\`

## Security 🔒
- \`/api/debug\` now requires \`X-Admin-Key\`
- Open-redirect on \`/login?redirect=…\` — restricted to same-origin paths
- XSS in \`promptForTripName\` — modal value set via DOM, not innerHTML
- XSS in share-modal user list — user nodes built via DOM/textContent

## Observability 📊
- \`/api/debug\` returns: \`new_users_24h\`, \`new_trips_24h\`, \`recent_users\` (last 10), and \`created_at\` on recent trips
- \`/api/register\` writes \`[SIGNUP] <user> @ <utc>\` to stdout for live monitoring
- \`scripts/launch-stats.sh\` — one-line CLI report against prod

## UX (full list in the commit message)
Sign Up CTA, footer, feedback popup, public-toggle copy, AI-helpers explainer, first-time intro, "Save Trip" vs "Publish", Add-to-trip flow, etc.

## Test plan
- [x] \`pytest tests/ -m "not integration"\` — 317 passing
- [x] \`ruff check . && ruff format --check .\` — clean
- [x] \`python3 scripts/check_file_size.py\` — clean
- [x] Local smoke: home, about, how-it-works, register, login, trips, create, explore, /api/debug all 200 (or 401 for debug without key)
- [ ] Verify on Render after merge: hit \`/api/debug\` with \`X-Admin-Key\`, eyeball home + register copy, click "Send feedback" popup
- [ ] After Render redeploy, run \`./scripts/launch-stats.sh\` to confirm the new fields are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)