### PR TITLE
Admin endpoint to delete users + fix hardcoded creds (GitGuardian)

### DIFF
--- a/agents/admin/routes.py
+++ b/agents/admin/routes.py
@@ -306,6 +306,40 @@ def admin_add_venues():
     return json_ok({"success": True, "added": added, "skipped": skipped})
 
 
+@admin_bp.post("/api/admin/delete-user")
+def admin_delete_user():
+    """Delete a user (and their trips, via FK CASCADE) by username. Useful
+    for cleaning up test/abandoned accounts pre-launch.
+
+    Protected by SECRET_KEY (X-Admin-Key header).
+    Refuses to delete the demo system user — that account owns the
+    demo trips that every new visitor sees.
+
+    Body JSON: {"username": "<name>"}
+    """
+    secret_key = os.environ.get("SECRET_KEY", "")
+    provided = request.headers.get("X-Admin-Key", "")
+    if not secret_key or provided != secret_key:
+        return json_err("Unauthorized", status=401)
+
+    data = request.get_json(silent=True) or {}
+    username = data.get("username", "").strip()
+    if not username:
+        return json_err("No username provided")
+
+    # Hardcoded refuse-list. The demo user is owned by the system; deleting
+    # it would orphan the curated demo trips on every fresh visit.
+    if username in {"demo", "system"}:
+        return json_err(f"Refusing to delete protected user '{username}'", status=400)
+
+    deleted = db.delete_user_by_username(username)
+    if not deleted:
+        return json_err(f"No user named '{username}' found", status=404)
+
+    print(f"[ADMIN] Deleted user '{username}' (and their trips via CASCADE)", flush=True)
+    return json_ok({"success": True, "username": username})
+
+
 @admin_bp.post("/api/regenerate-all-trips")
 @require_auth
 def regenerate_all_trips():

--- a/agents/auth/credentials.py
+++ b/agents/auth/credentials.py
@@ -38,17 +38,3 @@ def register_user(username: str, email: str, password: str) -> tuple[bool, str |
 def is_auth_enabled() -> bool:
     """Return True if authentication is active (AUTH_DISABLED env var not set)."""
     return os.environ.get("AUTH_DISABLED", "").lower() != "true"
-
-
-def ensure_default_user() -> None:
-    """Create a default admin user if none exists (initial setup helper)."""
-    default_username = os.environ.get("AUTH_USERNAME", "admin")
-    default_password = os.environ.get("AUTH_PASSWORD", "libertas")
-    default_email = os.environ.get("AUTH_EMAIL", "admin@example.com")
-
-    if not db.username_exists(default_username):
-        user_id = db.create_user(default_username, default_email, default_password)
-        if user_id:
-            print(f"[AUTH] Created default user: {default_username}")
-        else:
-            print("[AUTH] Failed to create default user")

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -41,6 +41,7 @@ from database.trips import (  # noqa: F401
 from database.users import (  # noqa: F401
     authenticate_user,
     create_user,
+    delete_user_by_username,
     email_exists,
     ensure_demo_user,
     get_all_users,

--- a/database/connection.py
+++ b/database/connection.py
@@ -195,6 +195,11 @@ def get_connection():
         db_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "libertas.db")
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
+        # SQLite ships with foreign keys disabled by default. Enabling them
+        # so ON DELETE CASCADE works consistently with Postgres in prod —
+        # otherwise deleting a user leaves orphaned trip rows behind in
+        # local dev only, masking real cascade bugs.
+        conn.execute("PRAGMA foreign_keys = ON")
         return conn
 
 

--- a/database/users.py
+++ b/database/users.py
@@ -33,6 +33,9 @@ _SQL_SQLITE_EMAIL_EXISTS = "SELECT 1 FROM users WHERE email = ?"
 
 _SQL_GET_ALL_USERS = "SELECT id, username FROM users ORDER BY username"
 
+_SQL_PG_DELETE_USER = "DELETE FROM users WHERE username = %s"
+_SQL_SQLITE_DELETE_USER = "DELETE FROM users WHERE username = ?"
+
 
 def hash_password(password: str) -> str:
     """Hash a password using bcrypt."""
@@ -199,3 +202,19 @@ def get_all_users() -> list[dict[str, Any]]:
             return [{"id": row[0], "username": row[1]} for row in cursor.fetchall()]
         else:
             return [dict(row) for row in cursor.fetchall()]
+
+
+def delete_user_by_username(username: str) -> bool:
+    """Delete a user (and their trips, via ON DELETE CASCADE on the trips
+    FK). Returns True if a row was deleted, False if no such user.
+
+    Used by the admin endpoint to clean up test accounts pre-launch.
+    Permanent — there is no undo. Don't use this on the demo system user.
+    """
+    with get_db() as conn:
+        cursor = conn.cursor()
+        if USE_POSTGRES:
+            cursor.execute(_SQL_PG_DELETE_USER, (username,))
+        else:
+            cursor.execute(_SQL_SQLITE_DELETE_USER, (username,))
+        return cursor.rowcount > 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,15 @@ def app():
 
     db.init_db()
 
+    # AUTH_DISABLED defaults g.user_id to 1 in agents/common/flask_utils.py.
+    # Tests POST trips/items as that user — the FK on trips.user_id needs
+    # the row to exist. SQLite previously let it slide silently; with
+    # PRAGMA foreign_keys=ON we now need to ensure user 1 exists. The
+    # first INSERT into the users table on CI gets id=1 because it's a
+    # fresh DB; locally libertas.db usually already has a user 1.
+    if not db.get_user_by_id(1):
+        db.create_user("test_owner", "test_owner@test.local", "test-password-12345")
+
     flask_app = create_app()
     flask_app.config["TESTING"] = True
     yield flask_app

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -151,6 +151,10 @@ class TestAdminAuth:
         )
         assert resp.status_code == 401
 
+    def test_delete_user_no_key_returns_401(self, client):
+        resp = client.post("/api/admin/delete-user", json={"username": "x"})
+        assert resp.status_code == 401
+
 
 # ---------------------------------------------------------------------------
 # Admin endpoints — with valid key
@@ -226,6 +230,66 @@ class TestAdminEndpoints:
         data = resp.get_json()
         assert data["skipped"] == 1
         assert data["added"] == 0
+
+    def test_delete_user_missing_username(self, client):
+        resp = client.post(
+            "/api/admin/delete-user",
+            headers=self.HEADERS,
+            json={},
+        )
+        assert resp.status_code in (200, 400)
+        assert resp.get_json().get("success") is not True
+
+    def test_delete_user_unknown_returns_404(self, client):
+        resp = client.post(
+            "/api/admin/delete-user",
+            headers=self.HEADERS,
+            json={"username": "definitely_not_a_real_user_12345"},
+        )
+        assert resp.status_code == 404
+
+    def test_delete_user_refuses_demo_user(self, client):
+        resp = client.post(
+            "/api/admin/delete-user",
+            headers=self.HEADERS,
+            json={"username": "demo"},
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body.get("success") is not True
+
+    def test_delete_user_round_trip(self, client):
+        """Create a throw-away user, delete it via the admin endpoint,
+        verify it's gone. Also confirms FK CASCADE wipes the user's trips."""
+        import database as db
+
+        username = "deleteme_round_trip"
+        # Clean up first in case a prior failed run left it behind
+        db.delete_user_by_username(username)
+
+        user_id = db.create_user(username, f"{username}@test.local", "pw1234")
+        assert user_id is not None
+
+        # Create a trip owned by this user — must vanish on cascade delete
+        link = "delete_round_trip_test.html"
+        db.add_trip(user_id, {"title": "Doomed Trip", "link": link}, {"days": [], "ideas": []})
+        assert db.get_trip_by_link(user_id, link) is not None
+
+        try:
+            resp = client.post(
+                "/api/admin/delete-user",
+                headers=self.HEADERS,
+                json={"username": username},
+            )
+            assert resp.status_code == 200
+            assert resp.get_json()["success"] is True
+
+            # User and their trip should both be gone
+            assert db.get_user_by_username(username) is None
+            assert db.get_trip_by_link(user_id, link) is None
+        finally:
+            # Defensive: in case the test failed mid-way
+            db.delete_user_by_username(username)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two fixes pre-launch:

## 1. New: \`POST /api/admin/delete-user\` 🧹
For cleaning up test/abandoned accounts before tomorrow's launch email.

\`\`\`bash
curl -X POST -H "X-Admin-Key: \$SECRET_KEY" -H "Content-Type: application/json" \\
  -d '{"username":"the-test-user"}' \\
  https://libertas-travel.onrender.com/api/admin/delete-user
\`\`\`

- Refuses to delete protected usernames (\`demo\`, \`system\`)
- Returns 404 for unknown usernames
- Logs a \`[ADMIN]\` line on success
- User's trips wiped via FK CASCADE on \`trips.user_id\`

## 2. Fix: GitGuardian "Username Password" alert 🔒
GG flagged a \`username='admin'\` / \`password='libertas'\` pair in \`agents/auth/credentials.py\`. The lines lived inside \`ensure_default_user()\` — a function that was **defined but never called from anywhere**. So nothing was actually exploitable, but having hardcoded fallback credentials in source is bad form and trips secret scanners.

Deleted the dead function. No callers, no behavior change.

## 3. Bug fix: SQLite was not enforcing FOREIGN KEY constraints
Postgres in prod always enforces FKs. Local-dev SQLite ships with FK enforcement off by default. This meant \`ON DELETE CASCADE\` (used by trips → users) was silently ignored locally — orphan trip rows would accumulate after a delete in dev only.

Enabled \`PRAGMA foreign_keys = ON\` on every SQLite connection. Local now matches prod. The new delete-user round-trip test would otherwise have failed locally but passed in CI (Postgres) — now consistent.

## Test plan
- [x] \`pytest tests/ -m "not integration"\` — 322 passing (5 new tests in TestAdminEndpoints)
- [x] \`ruff check . && ruff format --check .\` — clean
- [x] \`python3 scripts/check_file_size.py\` — clean
- [x] Local smoke: 401 without key, 400 for demo user, 404 for unknown, 200 for round-trip
- [ ] On Render after merge: re-scan should clear the GitGuardian alert; \`/api/admin/delete-user\` ready to clean up test accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)