### PR TITLE
Fill Missing Links also fills missing locations

### DIFF
--- a/agents/create/templates/create.html
+++ b/agents/create/templates/create.html
@@ -186,12 +186,12 @@
                         <button class="trip-tools-hint-close" id="trip-tools-hint-close" aria-label="Hide this hint" title="Hide — won't show again">&times;</button>
                         <p class="trip-tools-hint-title"><i class="fas fa-magic"></i> Two AI helpers</p>
                         <ul class="trip-tools-hint-list">
-                            <li><strong>Fill Missing Links</strong> — finds website + Google Maps URLs for items that don't have them yet.</li>
+                            <li><strong>Fill Missing Links</strong> — for items missing them, fills in a location (so the map plots correctly), an official website, and a Google Maps URL.</li>
                             <li><strong>Generate Write-up</strong> — produces a readable narrative of the trip you can share or paste into an email.</li>
                         </ul>
                     </div>
                     <button class="btn-fill-links" id="fill-links-btn"
-                            title="Use AI to find website + Google Maps URLs for items that are missing them">
+                            title="AI fills in missing locations, website URLs, and Google Maps links across all items">
                         <i class="fas fa-link"></i> Fill Missing Links
                     </button>
                     <button class="btn-writeup" id="generate-writeup-btn"

--- a/agents/trips/handler.py
+++ b/agents/trips/handler.py
@@ -91,7 +91,10 @@ def generate_writeup_for_trip(user_id: int, link: str) -> tuple[dict, int]:
 
 
 def fill_links_for_trip(user_id: int, link: str) -> tuple[dict, int]:
-    """Use LLM to find website/maps URLs for items missing them."""
+    """Fill in missing locations / website URLs / Google Maps URLs across
+    every item in a trip. Trip title is passed for LLM context so
+    ambiguous item names ("Marienplatz", "Hofbräuhaus") resolve to the
+    right city instead of the geocoder's silent guess."""
     trip, itinerary_data = _load_trip_with_itinerary(user_id, link)
     if not trip:
         return {"error": "Trip not found"}, 404
@@ -99,7 +102,7 @@ def fill_links_for_trip(user_id: int, link: str) -> tuple[dict, int]:
     from agents.trips.link_resolver import fill_missing_links
 
     try:
-        result = fill_missing_links(itinerary_data)
+        result = fill_missing_links(itinerary_data, trip_title=trip.get("title", ""))
         db.update_trip_itinerary_data(user_id, link, itinerary_data)
     except Exception as e:
         return {"error": f"Link resolution failed: {e}"}, 500

--- a/agents/trips/link_resolver.py
+++ b/agents/trips/link_resolver.py
@@ -1,4 +1,4 @@
-"""Resolve missing website URLs and Google Maps links for trip items."""
+"""Resolve missing website URLs, Google Maps links, and locations for trip items."""
 
 from __future__ import annotations
 
@@ -9,68 +9,148 @@ from typing import Any
 from agents.common.llm import SONNET, make_llm
 
 
-def fill_missing_links(itinerary_data: dict[str, Any]) -> dict:
-    """Find and fill missing website/maps links for all items.
+def fill_missing_links(itinerary_data: dict[str, Any], trip_title: str = "") -> dict:
+    """Fill in missing location, website, and Google Maps URL fields on all
+    items in a trip. Order matters: locations are filled FIRST so the
+    other fillers can use the freshly-added city for disambiguation.
 
-    Returns {"updated": count, "items": [{"title": ..., "website": ...}, ...]}
+    Why locations matter: with no location, the geocoder uses just the
+    item title. That works for "Hohenschwangau Castle" but breaks for
+    ambiguous names like "Marienplatz" (Munich, Cologne, Stuttgart, ...)
+    or "Hofbräuhaus" — the geocoder picks the wrong city silently and the
+    map ends up with markers in the wrong country.
+
+    Returns: {"locations_added": N, "maps_added": N, "websites_added": N}.
     """
     all_items = list(itinerary_data.get("ideas", []))
     for day in itinerary_data.get("days", []):
         all_items.extend(day.get("items", []))
 
-    # Add maps links for items missing them
-    maps_added = 0
-    for item in all_items:
+    locations_added = _fill_missing_locations(all_items, trip_title)
+    maps_added = _fill_missing_maps_links(all_items)
+    websites_added = _fill_missing_websites(all_items)
+
+    return {
+        "locations_added": locations_added,
+        "maps_added": maps_added,
+        "websites_added": websites_added,
+    }
+
+
+def _fill_missing_locations(items: list[dict], trip_title: str) -> int:
+    """For each item with no location, ask the LLM for a 'City, Country'
+    string. Trip-level context (title + the locations of items that DO
+    have one) is passed in so the model can infer the right city for
+    ambiguous titles."""
+    need_location = [i for i in items if not (i.get("location") or "").strip()]
+    if not need_location:
+        return 0
+
+    # Collect known locations to give the model trip-level context
+    known_locations = sorted(
+        {(i.get("location") or "").strip() for i in items if (i.get("location") or "").strip()}
+    )
+    context_lines = []
+    if trip_title:
+        context_lines.append(f"Trip: {trip_title}")
+    if known_locations:
+        context_lines.append("Other items in this trip are located in:")
+        for loc in known_locations[:10]:
+            context_lines.append(f"  - {loc}")
+    context = "\n".join(context_lines) if context_lines else "(no other context)"
+
+    titles = "\n".join(f"- {i.get('title', '')}" for i in need_location if i.get("title"))
+
+    try:
+        llm = make_llm(model=SONNET, max_tokens=1024)
+        response = llm.call_api(
+            system_prompt=(
+                "You assign a 'City, Country' location to travel itinerary items. "
+                "Return ONLY a JSON object mapping each item title (verbatim) to "
+                'a "City, Country" string. If you cannot determine the city with '
+                "high confidence, OMIT that item from the response — never guess. "
+                "Use the trip context to disambiguate names that exist in multiple "
+                "cities. No markdown fences, no commentary."
+            ),
+            messages=[
+                {
+                    "role": "user",
+                    "content": (f"{context}\n\nFill in 'City, Country' for these items:\n{titles}"),
+                }
+            ],
+            return_full_response=True,
+        )
+        text = response.content[0].text.strip()
+        text = re.sub(r"^```\w*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text)
+        suggestions = json.loads(text)
+    except Exception as e:
+        print(f"[LINKS] Location fill failed: {e}")
+        return 0
+
+    added = 0
+    for item in need_location:
+        suggested = suggestions.get(item.get("title", ""))
+        if isinstance(suggested, str) and "," in suggested:
+            item["location"] = suggested.strip()
+            added += 1
+    return added
+
+
+def _fill_missing_maps_links(items: list[dict]) -> int:
+    """Stub a Google Maps search URL for any item missing one."""
+    added = 0
+    for item in items:
         if not item.get("google_maps_link"):
             title = item.get("title", "")
             loc = item.get("location", "")
             if title:
                 q = f"{title} {loc}".strip().replace(" ", "%20")
                 item["google_maps_link"] = f"https://www.google.com/maps/search/?api=1&query={q}"
-                maps_added += 1
+                added += 1
+    return added
 
-    # Find items needing real websites
+
+def _fill_missing_websites(items: list[dict]) -> int:
+    """Ask the LLM for official websites for items missing one. Items
+    whose existing website is a Google search fallback are also re-tried."""
     need_website = [
-        i
-        for i in all_items
-        if not i.get("website") or "google.com/search" in str(i.get("website", ""))
+        i for i in items if not i.get("website") or "google.com/search" in str(i.get("website", ""))
     ]
+    if not need_website:
+        return 0
 
-    websites_added = 0
-    if need_website:
-        names = "\n".join(f"- {i['title']} in {i.get('location', '')}" for i in need_website)
-        try:
-            llm = make_llm(model=SONNET, max_tokens=2048)
-            response = llm.call_api(
-                system_prompt="Return ONLY valid JSON, no markdown fences, no other text.",
-                messages=[
-                    {
-                        "role": "user",
-                        "content": (
-                            "Find official website URLs for these venues. "
-                            "Return JSON mapping name to url. Omit if unknown.\n\n"
-                            f"{names}"
-                        ),
-                    }
-                ],
-                return_full_response=True,
-            )
+    names = "\n".join(f"- {i['title']} in {i.get('location', '')}" for i in need_website)
+    try:
+        llm = make_llm(model=SONNET, max_tokens=2048)
+        response = llm.call_api(
+            system_prompt="Return ONLY valid JSON, no markdown fences, no other text.",
+            messages=[
+                {
+                    "role": "user",
+                    "content": (
+                        "Find official website URLs for these venues. "
+                        "Return JSON mapping name to url. Omit if unknown.\n\n"
+                        f"{names}"
+                    ),
+                }
+            ],
+            return_full_response=True,
+        )
+        text = response.content[0].text.strip()
+        text = re.sub(r"^```\w*\n?", "", text)
+        text = re.sub(r"\n?```$", "", text)
+        websites = json.loads(text)
+    except Exception as e:
+        print(f"[LINKS] Website lookup failed: {e}")
+        return 0
 
-            text = response.content[0].text.strip()
-            text = re.sub(r"^```\w*\n?", "", text)
-            text = re.sub(r"\n?```$", "", text)
-
-            websites = json.loads(text)
-            for item in need_website:
-                url = websites.get(item["title"])
-                if url and isinstance(url, str) and url.startswith("http"):
-                    item["website"] = url
-                    websites_added += 1
-                elif (
-                    isinstance(item.get("website"), str) and "google.com/search" in item["website"]
-                ):
-                    item["website"] = ""  # Clear Google search fallback
-        except Exception as e:
-            print(f"[LINKS] Website lookup failed: {e}")
-
-    return {"maps_added": maps_added, "websites_added": websites_added}
+    added = 0
+    for item in need_website:
+        url = websites.get(item["title"])
+        if url and isinstance(url, str) and url.startswith("http"):
+            item["website"] = url
+            added += 1
+        elif isinstance(item.get("website"), str) and "google.com/search" in item["website"]:
+            item["website"] = ""  # Clear stale Google search fallback
+    return added

--- a/tests/test_link_resolver.py
+++ b/tests/test_link_resolver.py
@@ -1,0 +1,104 @@
+"""Tests for the link/location filler that wires the 'Fill Missing Links'
+button. The LLM is stubbed — these tests cover the orchestration logic,
+not the model's choices."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _stub_llm(text: str):
+    """Build a MagicMock that mimics fiat-lux-agents' LLMBase.call_api
+    when called with return_full_response=True."""
+    fake = MagicMock()
+    fake.call_api.return_value.content = [MagicMock(text=text)]
+    return fake
+
+
+class TestFillMissingLocations:
+    def test_fills_location_for_items_with_none(self):
+        from agents.trips.link_resolver import _fill_missing_locations
+
+        items = [
+            {"title": "Christkindlmarkt at Marienplatz"},
+            {"title": "Hotel Drei Raben", "location": "Nuremberg, Germany"},
+        ]
+        with patch(
+            "agents.trips.link_resolver.make_llm",
+            return_value=_stub_llm('{"Christkindlmarkt at Marienplatz": "Munich, Germany"}'),
+        ):
+            added = _fill_missing_locations(items, trip_title="German Xmas Markets")
+        assert added == 1
+        assert items[0]["location"] == "Munich, Germany"
+        assert items[1]["location"] == "Nuremberg, Germany"  # unchanged
+
+    def test_skips_items_when_llm_omits_them(self):
+        """Per the prompt, the model is told to OMIT items it can't place
+        with confidence rather than guess. Make sure we honor that."""
+        from agents.trips.link_resolver import _fill_missing_locations
+
+        items = [{"title": "Some Generic Cafe"}]
+        with patch(
+            "agents.trips.link_resolver.make_llm",
+            return_value=_stub_llm("{}"),
+        ):
+            added = _fill_missing_locations(items, trip_title="Trip")
+        assert added == 0
+        assert "location" not in items[0] or not items[0]["location"]
+
+    def test_no_items_need_filling_short_circuits(self):
+        from agents.trips.link_resolver import _fill_missing_locations
+
+        items = [
+            {"title": "A", "location": "Munich, Germany"},
+            {"title": "B", "location": "Paris, France"},
+        ]
+        with patch("agents.trips.link_resolver.make_llm") as mk:
+            added = _fill_missing_locations(items, trip_title="x")
+        assert added == 0
+        mk.assert_not_called()  # no items need filling -> no LLM call
+
+    def test_rejects_response_without_comma(self):
+        """A 'City, Country' string should have a comma — single-word
+        responses are rejected as low-confidence."""
+        from agents.trips.link_resolver import _fill_missing_locations
+
+        items = [{"title": "Mystery"}]
+        with patch(
+            "agents.trips.link_resolver.make_llm",
+            return_value=_stub_llm('{"Mystery": "somewhere"}'),
+        ):
+            added = _fill_missing_locations(items, trip_title="Trip")
+        assert added == 0
+
+    def test_empty_string_location_is_treated_as_missing(self):
+        """An item with `location: ""` should be considered location-less."""
+        from agents.trips.link_resolver import _fill_missing_locations
+
+        items = [{"title": "X", "location": ""}, {"title": "Y", "location": "  "}]
+        with patch(
+            "agents.trips.link_resolver.make_llm",
+            return_value=_stub_llm('{"X": "Munich, Germany", "Y": "Berlin, Germany"}'),
+        ):
+            added = _fill_missing_locations(items, trip_title="Germany trip")
+        assert added == 2
+
+
+class TestFillMissingLinks:
+    """Orchestration: locations fill first so maps URLs include the city."""
+
+    def test_locations_run_before_maps_so_query_includes_city(self):
+        from agents.trips.link_resolver import fill_missing_links
+
+        item = {"title": "Marienplatz"}
+        with patch(
+            "agents.trips.link_resolver.make_llm",
+            return_value=_stub_llm('{"Marienplatz": "Munich, Germany"}'),
+        ):
+            result = fill_missing_links(
+                {"days": [{"items": [item]}], "ideas": []},
+                trip_title="Germany",
+            )
+        assert result["locations_added"] == 1
+        # Maps URL should include the freshly-added city, not just the title
+        assert "Munich" in item["google_maps_link"]


### PR DESCRIPTION
## The bug
On the German Christmas Markets trip on prod, two map markers were in completely wrong cities — \`Marienplatz\` placed in Cologne instead of Munich; \`Markt der Partnerstädte\` in the Black Forest instead of Nuremberg.

Root cause: those items had **no \`location\` field at all**. The geocoder fell back to the bare title — which is unambiguous for "Hohenschwangau Castle" but disastrous for ambiguous names like "Marienplatz" (a square in many German cities). Re-running the geocoder ("Regen Map") gave the same wrong answer because it had the same wrong input.

The fix has to update the items, not the geocoder.

## The fix
"Fill Missing Links" was already the "make my items healthy" button. Extended it to also fill missing locations.

- Refactored \`agents/trips/link_resolver.py\` into three steps: locations, maps URLs, websites. Locations run **first** so the maps-URL query string includes the freshly-added city.
- The location filler is LLM-driven with trip-level context: the trip title + the locations of items that DO have one. So when "Marienplatz" appears in a trip already containing items in "Munich, Germany", the model places it correctly.
- Conservative: the prompt tells the model to OMIT items it can't place with high confidence, and we reject any response missing a comma. Better unfilled than wrong.

## Test plan
- [x] 5 new unit tests in \`tests/test_link_resolver.py\` covering filled, omitted, short-circuit, comma-required, and empty-string-treated-as-missing
- [x] Full suite — 328 passing
- [x] \`ruff check . && ruff format --check .\` — clean
- [ ] After merge, hit "Fill Missing Links" on the German Xmas Markets trip then "Regen Map" — markers should land in the right cities

🤖 Generated with [Claude Code](https://claude.com/claude-code)