### PR TITLE
Admin endpoint to delete a single trip by username + link

### DIFF
--- a/agents/admin/routes.py
+++ b/agents/admin/routes.py
@@ -326,6 +326,39 @@ def admin_add_venues():
     return json_ok({"success": True, "added": added, "skipped": skipped})
 
 
+@admin_bp.post("/api/admin/delete-trip")
+def admin_delete_trip():
+    """Delete a single trip by username + link. Useful when a trip needs
+    to come out of the public list (or out entirely) and the owner can't
+    log in to do it themselves — common for the `demo` user.
+
+    Protected by SECRET_KEY (X-Admin-Key header).
+
+    Body JSON: {"username": "<owner>", "link": "<trip-link.html>"}
+    """
+    secret_key = os.environ.get("SECRET_KEY", "")
+    provided = request.headers.get("X-Admin-Key", "")
+    if not secret_key or provided != secret_key:
+        return json_err("Unauthorized", status=401)
+
+    data = request.get_json(silent=True) or {}
+    username = data.get("username", "").strip()
+    link = data.get("link", "").strip()
+    if not username or not link:
+        return json_err("Both 'username' and 'link' are required")
+
+    user = db.get_user_by_username(username)
+    if not user:
+        return json_err(f"No user named '{username}' found", status=404)
+
+    deleted = db.delete_trip(user["id"], link)
+    if not deleted:
+        return json_err(f"No trip with link '{link}' found for user '{username}'", status=404)
+
+    print(f"[ADMIN] Deleted trip '{link}' from user '{username}'", flush=True)
+    return json_ok({"success": True, "username": username, "link": link})
+
+
 @admin_bp.post("/api/admin/delete-user")
 def admin_delete_user():
     """Delete a user (and their trips, via FK CASCADE) by username. Useful

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -155,6 +155,10 @@ class TestAdminAuth:
         resp = client.post("/api/admin/delete-user", json={"username": "x"})
         assert resp.status_code == 401
 
+    def test_delete_trip_no_key_returns_401(self, client):
+        resp = client.post("/api/admin/delete-trip", json={"username": "x", "link": "y.html"})
+        assert resp.status_code == 401
+
 
 # ---------------------------------------------------------------------------
 # Admin endpoints — with valid key
@@ -257,6 +261,55 @@ class TestAdminEndpoints:
         assert resp.status_code == 400
         body = resp.get_json()
         assert body.get("success") is not True
+
+    def test_delete_trip_round_trip(self, client):
+        """Create a user + trip, delete via the admin endpoint, verify gone."""
+        import database as db
+
+        username = "trip_owner_for_delete"
+        link = "doomed_trip_for_admin_delete.html"
+        db.delete_user_by_username(username)  # cleanup any prior run
+
+        user_id = db.create_user(username, f"{username}@test.local", "pw1234")
+        assert user_id is not None
+        db.add_trip(user_id, {"title": "Doomed", "link": link}, {"days": [], "ideas": []})
+        assert db.get_trip_by_link(user_id, link) is not None
+
+        try:
+            resp = client.post(
+                "/api/admin/delete-trip",
+                headers=self.HEADERS,
+                json={"username": username, "link": link},
+            )
+            assert resp.status_code == 200
+            assert resp.get_json()["success"] is True
+            assert db.get_trip_by_link(user_id, link) is None
+
+            # Re-deleting same trip yields 404
+            resp = client.post(
+                "/api/admin/delete-trip",
+                headers=self.HEADERS,
+                json={"username": username, "link": link},
+            )
+            assert resp.status_code == 404
+        finally:
+            db.delete_user_by_username(username)
+
+    def test_delete_trip_unknown_user(self, client):
+        resp = client.post(
+            "/api/admin/delete-trip",
+            headers=self.HEADERS,
+            json={"username": "no_such_user_xyz", "link": "anything.html"},
+        )
+        assert resp.status_code == 404
+
+    def test_delete_trip_missing_fields(self, client):
+        resp = client.post(
+            "/api/admin/delete-trip",
+            headers=self.HEADERS,
+            json={"username": "x"},  # no link
+        )
+        assert resp.get_json().get("success") is not True
 
     def test_delete_user_round_trip(self, client):
         """Create a throw-away user, delete it via the admin endpoint,


### PR DESCRIPTION
Companion to \`/api/admin/delete-user\`. Lets the owner clean up a specific trip belonging to any user — useful when the trip's owner can't (or shouldn't) log in to do it themselves (e.g. the \`demo\` system user).

Today's trigger: \`demo\`'s \`jackson.html\` and \`aab\`'s \`jackson.html\` share the same URL slug, which is causing public-link confusion at \`/r/jackson\`. Dropping demo's copy is the cleanest fix.

\`\`\`
POST /api/admin/delete-trip
  Headers: X-Admin-Key: <SECRET_KEY>
  Body:    {"username": "...", "link": "...html"}
\`\`\`

## Test plan
- [x] 3 new tests covering 401, round-trip (create + delete + verify gone + re-delete=404), and missing-fields
- [x] Full suite — 332 passing
- [x] Lint + format — clean

After merge:
\`\`\`bash
bash -c 'source ~/.profile && curl -X POST -H "X-Admin-Key: \$SECRET_KEY" -H "Content-Type: application/json" \
  -d "{\"username\":\"demo\",\"link\":\"jackson.html\"}" \
  https://libertas-travel.onrender.com/api/admin/delete-trip'
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)