### PR TITLE
Discoverability fixes for import, share, explore, view (#49)

### DIFF
--- a/agents/explore/static/js/explore-trip.js
+++ b/agents/explore/static/js/explore-trip.js
@@ -172,8 +172,40 @@ async function sendToTrip(btn, tripLink, venueData, note) {
             btn.innerHTML = '<i class="fas fa-check"></i> Added';
             btn.disabled = true;
             btn.classList.add('added');
+            // Surface a "View trip" link so users discover where the venue went.
+            // Without this, adds feel like a black hole on first use.
+            const tripTitle = (_tripsCache || []).find(t => t.link === tripLink)?.title || 'trip';
+            showAddedToast(venueData.name, tripTitle, tripLink);
         }
     } catch { /* silently fail */ }
+}
+
+function showAddedToast(venueName, tripTitle, tripLink) {
+    let toast = document.getElementById('explore-added-toast');
+    if (!toast) {
+        toast = document.createElement('div');
+        toast.id = 'explore-added-toast';
+        toast.style.cssText = (
+            'position:fixed;bottom:24px;left:50%;transform:translateX(-50%);' +
+            'background:#1a1a2e;color:#fff;padding:12px 18px;border-radius:10px;' +
+            'box-shadow:0 4px 20px rgba(0,0,0,0.25);z-index:9999;font-size:0.95rem;' +
+            'display:flex;align-items:center;gap:14px;max-width:90vw;'
+        );
+        document.body.appendChild(toast);
+    }
+    const safeVenue = (venueName || '').replace(/[<>&"]/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;'}[c]));
+    const safeTitle = (tripTitle || '').replace(/[<>&"]/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;'}[c]));
+    toast.innerHTML = (
+        `<span><i class="fas fa-check-circle" style="color:#7ed957;margin-right:6px;"></i>` +
+        `Added <strong>${safeVenue}</strong> to ${safeTitle}</span>` +
+        `<a href="/${encodeURIComponent(tripLink)}" style="color:#a8b4ff;text-decoration:underline;font-weight:600;">View trip</a>`
+    );
+    toast.style.opacity = '1';
+    clearTimeout(showAddedToast._t);
+    showAddedToast._t = setTimeout(() => {
+        toast.style.transition = 'opacity 0.4s';
+        toast.style.opacity = '0';
+    }, 5000);
 }
 
 // Legacy alias

--- a/agents/itinerary/templates.py
+++ b/agents/itinerary/templates.py
@@ -491,12 +491,12 @@ def generate_trips_page(trips: list[dict], public_trips: list[dict] = None) -> s
     if active_cards_list:
         trip_cards = "\n".join(active_cards_list)
     else:
-        # Empty-state CTA — friendlier than a blank grid for first-time users
+        # Empty-state CTA, friendlier than a blank grid for first-time users
         trip_cards = (
             '<div class="no-trips">'
             '<i class="fas fa-suitcase"></i>'
             "<h3>No trips yet</h3>"
-            "<p>Create one from scratch, or drop a confirmation PDF into the import area above.</p>"
+            "<p>Three ways to start: drop a confirmation PDF, paste a Google Maps directions link, or chat your way through a new trip from scratch.</p>"
             '<a href="/create.html" class="cta-button cta-button-primary">'
             '<i class="fas fa-plus"></i> Create your first trip</a>'
             "</div>"

--- a/agents/itinerary/templates/trips.html
+++ b/agents/itinerary/templates/trips.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/categories.css">
-    <link rel="stylesheet" href="/static/css/trips.css?v=12">
+    <link rel="stylesheet" href="/static/css/trips.css?v=13">
     <link rel="stylesheet" href="/static/css/trips-actions.css?v=1">
     <link rel="stylesheet" href="/static/css/trips-share-map.css?v=1">
 </head>
@@ -128,13 +128,13 @@
                 <p>Share "<span id="share-trip-title"></span>" with:</p>
                 <div class="share-options">
                     <button class="share-option-btn share-link-btn" onclick="copyItineraryLink()">
-                        <i class="fas fa-calendar-alt"></i> Itinerary Link
+                        <i class="fas fa-calendar-alt"></i> Share full itinerary
                     </button>
                     <button class="share-option-btn share-link-btn" onclick="copyRecommendationLink()">
-                        <i class="fas fa-lightbulb"></i> Recommendation Link
+                        <i class="fas fa-lightbulb"></i> Share as recommendation list
                     </button>
                     <button class="share-option-btn share-link-btn" onclick="copyWriteupLink()">
-                        <i class="fas fa-pen-fancy"></i> Write-up Link
+                        <i class="fas fa-pen-fancy"></i> Share as written narrative
                     </button>
                     <div class="share-divider">or share with a user</div>
                     <button class="share-option-btn" onclick="shareWithAll()">
@@ -153,6 +153,6 @@
     <script src="/static/js/main.js?v=7"></script>
     <script src="/static/js/archive.js?v=1"></script>
     <script src="/static/js/upload.js?v=9"></script>
-    <script src="/static/js/trips.js?v=8"></script>
+    <script src="/static/js/trips.js?v=9"></script>
 </body>
 </html>

--- a/static/css/trips.css
+++ b/static/css/trips.css
@@ -218,19 +218,22 @@
     position: relative;
 }
 
-.trip-card-wrapper:hover .trip-card-actions {
-    opacity: 1;
-}
-
+/* Trip card actions are always visible. Previously hover-only, which
+   meant new users never knew share / archive / public-toggle existed.
+   Slight opacity dip when not hovering keeps them from competing with
+   the card title for attention. */
 .trip-card-actions {
     position: absolute;
     top: 10px;
     right: 10px;
     display: flex;
     gap: 8px;
-    opacity: 0;
+    opacity: 0.85;
     transition: opacity 0.2s ease;
     z-index: 10;
+}
+.trip-card-wrapper:hover .trip-card-actions {
+    opacity: 1;
 }
 
 .trip-action-btn {

--- a/static/js/trips.js
+++ b/static/js/trips.js
@@ -95,7 +95,7 @@ function initListView() {
             '<div class="no-trips">' +
             '<i class="fas fa-suitcase"></i>' +
             '<h3>No trips yet</h3>' +
-            '<p>Create one from scratch, or drop a confirmation PDF into the import area above.</p>' +
+            '<p>Three ways to start: drop a confirmation PDF, paste a Google Maps directions link, or chat your way through a new trip from scratch.</p>' +
             '<a href="/create.html" class="cta-button cta-button-primary">' +
             '<i class="fas fa-plus"></i> Create your first trip</a>' +
             '</div>'


### PR DESCRIPTION
## Summary
- Trip card actions are always visible (opacity 0.85, full on hover) so new users discover share/archive/public-toggle.
- Empty-state copy on /trips lists three ways to start: PDF drop, Google Maps link, or chat.
- Share modal labels reworded to be self-explanatory ("Share full itinerary" instead of "Itinerary Link", etc.).
- Explore add-to-trip surfaces a toast with a "View trip" link after a successful add.

Closes #49.

## Test plan
- [ ] Visit /trips logged out, confirm empty-state copy reads correctly
- [ ] Visit /trips with trips, confirm action buttons visible without hover
- [ ] Click share, confirm new label text
- [ ] On /explore, add a venue to a trip, confirm toast + "View trip" link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)