### PR TITLE
Post-launch fixes: discoverability + image/year regressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,8 @@ Every shared lookup table, config object, or utility must be defined **once** an
 - Tests must be repeatable: no hardcoded local paths, no reliance on live APIs unless marked `@pytest.mark.integration`
 - If a change touches fiat-lux-agents (`~/repos/fiat-lux-agents`), also run its tests: `.venv/bin/python3 -m pytest ~/repos/fiat-lux-agents/tests/ -x -q`
 - Whenever new tests are written, add a comment to issue #15 (test suite tracking) — even if the issue is closed
+- **Preserve coverage during refactors.** When splitting a file, renaming a module, or moving logic around, every conditional branch (especially `if/elif/else` chains for file types, error paths, or feature flags) must still be exercised by a test after the refactor. If you find a branch that has no test, write one *before* you refactor — that turns the branch into a tripwire. The PNG-upload regression in commit `1ef25bb` (2517-line handler split) silently dropped the vision-API call for weeks because no test covered image uploads. Don't repeat that.
+- Refactor checklist: list the conditional branches in the old file, run `pytest -k <name>` against each, refactor, re-run. If a branch had no test, add one *first*.
 
 ## Naming
 - Always write out "fiat-lux-agents" in full, in code, comments, docs, issues, and PR descriptions

--- a/agents/create/templates/create.html
+++ b/agents/create/templates/create.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/categories.css">
     <link rel="stylesheet" href="/static/css/create.css?v=21">
-    <link rel="stylesheet" href="/static/css/create-content.css?v=3">
+    <link rel="stylesheet" href="/static/css/create-content.css?v=5">
     <link rel="stylesheet" href="/static/css/create-chat.css?v=1">
     <link rel="stylesheet" href="/static/css/create-views.css?v=1">
 </head>
@@ -113,6 +113,15 @@
 
                 <!-- Itinerary Tab Content -->
                 <div class="timeline-tab-content active" id="itinerary-tab">
+                    <!-- Dismissible drag-drop discoverability tip. Hidden once
+                         the user clicks the X (libertas_seen_dragdrop_tip in
+                         localStorage). Shown above Day 1 because that is where
+                         the eye lands first after import. -->
+                    <div class="dragdrop-tip" id="dragdrop-tip" hidden>
+                        <button class="dragdrop-tip-close" id="dragdrop-tip-close" aria-label="Dismiss">&times;</button>
+                        <i class="fas fa-lightbulb"></i>
+                        <span>Tip: drop another flight or hotel confirmation <strong>anywhere on this page</strong> to add it to this trip. Or use the <strong>Upload Plan</strong> button at the bottom.</span>
+                    </div>
                     <div class="days-container" id="days-container">
                         <!-- Days will be added here dynamically -->
                     </div>
@@ -160,10 +169,12 @@
                         </div>
                     </div>
                     <div class="ideas-actions">
-                        <button class="btn-add-idea" id="add-idea-btn">
+                        <button class="btn-add-idea" id="add-idea-btn"
+                                title="Add a single item by hand (a restaurant, hotel, activity, etc.)">
                             <i class="fas fa-plus"></i> Add Idea
                         </button>
-                        <button class="btn-upload-plan" id="upload-plan-btn">
+                        <button class="btn-upload-plan" id="upload-plan-btn"
+                                title="Upload another booking PDF, .ics, email, or itinerary text. Items get added to this trip's Ideas pile.">
                             <i class="fas fa-file-upload"></i> Upload Plan
                         </button>
                     </div>
@@ -356,7 +367,7 @@
         var params = new URLSearchParams(window.location.search);
         var tripLink = params.get('link') || params.get('edit');
     </script>
-    <script src="/static/js/create.js?v=55"></script>
+    <script src="/static/js/create.js?v=58"></script>
     <script src="/static/js/create-render.js?v=2"></script>
     <script src="/static/js/create-items.js?v=3"></script>
     <script src="/static/js/create-upload.js?v=3"></script>

--- a/agents/create/upload_handlers.py
+++ b/agents/create/upload_handlers.py
@@ -195,7 +195,6 @@ def upload_file_handler(
     user_id: int, file_data: bytes, filename: str, output_dir: Path | None = None
 ) -> tuple[dict, int]:
     """Process an uploaded itinerary file. Returns (result, status_code)."""
-    import tempfile
     import time
 
     from agents.create.itinerary_utils import _convert_to_itinerary
@@ -286,11 +285,14 @@ def upload_file_handler(
                         }, 400
                 itinerary = parser.parse_text(text, source_url=filename)
             elif "image_data" in extracted:
-                # Scanned PDF or image, write to tmp for parse_file
-                with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
-                    tmp.write(file_data)
-                    tmp_path = tmp.name
-                itinerary = parser.parse_file(tmp_path)
+                # Image upload (PNG / JPG / scanned PDF page). Use the parser's
+                # vision path; the previous tmp-file + parse_file flow only
+                # supported PDF and Excel and 400'd on every image upload.
+                itinerary = parser.parse_image(
+                    image_data=extracted["image_data"],
+                    media_type=extracted.get("media_type", "image/png"),
+                    source_file=filename,
+                )
             else:
                 return {"error": "Could not extract content from file"}, 400
             print(

--- a/agents/itinerary/parser.py
+++ b/agents/itinerary/parser.py
@@ -46,7 +46,32 @@ def fix_json_string(json_str: str) -> str:
     return json_str
 
 
-EXTRACTION_PROMPT = """You are an expert at extracting structured travel itinerary data from text.
+def _build_extraction_prompt() -> str:
+    """Render the extraction prompt with today's date baked in.
+
+    The year-resolution rule MUST be re-rendered each call because
+    confirmations rarely include the year (e.g. "Wed, 20MAY"). Without
+    today's date in the prompt the LLM picks whichever year matches the
+    weekday, often 5+ years in the past. Use plain str.replace because
+    the prompt body contains JSON example braces that would trip
+    str.format.
+    """
+    today = datetime.now()
+    return (
+        _EXTRACTION_PROMPT_TEMPLATE.replace("{{CURRENT_DATE}}", today.strftime("%Y-%m-%d"))
+        .replace("{{CURRENT_YEAR}}", str(today.year))
+        .replace("{{NEXT_YEAR}}", str(today.year + 1))
+    )
+
+
+_EXTRACTION_PROMPT_TEMPLATE = """You are an expert at extracting structured travel itinerary data from text.
+
+Today's date is {{CURRENT_DATE}}.
+
+When a date in the source omits the year (very common on flight confirmations like "Wed, 20MAY"), use this rule:
+- If the month/day is still upcoming this year, use {{CURRENT_YEAR}}
+- If the month/day has already passed this year, use {{NEXT_YEAR}}
+- Never pick a year more than 1 year in the past based on weekday matching alone
 
 Analyze the following text from a travel itinerary document and extract all relevant information.
 
@@ -132,6 +157,56 @@ class ItineraryParser:
         """Parse an itinerary from raw text (e.g., from HTML page)."""
         return self._parse_with_claude(text, source_url)
 
+    def parse_image(self, image_data: str, media_type: str, source_file: str) -> Itinerary:
+        """Parse an itinerary from a base64-encoded image (PNG/JPG/etc.).
+
+        Calls Claude's vision API with the image plus the standard extraction
+        prompt. Used for screenshots and image confirmations that the
+        text-based parse_file() can't handle.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": image_data,
+                        },
+                    },
+                    {"type": "text", "text": _build_extraction_prompt()},
+                ],
+            }
+        ]
+        response_text = self.llm.call_api(system_prompt="", messages=messages)
+        return self._parse_response_text(response_text, source_file)
+
+    def _parse_response_text(self, response_text: str, source_file: str) -> Itinerary:
+        """Shared post-processing: pull JSON out of an LLM response and build
+        an Itinerary. Factored out so parse_text and parse_image can share it.
+        """
+        if "```json" in response_text:
+            json_str = response_text.split("```json")[1].split("```")[0].strip()
+        elif "```" in response_text:
+            json_str = response_text.split("```")[1].split("```")[0].strip()
+        else:
+            json_str = response_text.strip()
+        json_str = fix_json_string(json_str)
+        try:
+            data = json.loads(json_str)
+        except json.JSONDecodeError as e:
+            lines = json_str.split("\n")
+            error_line = e.lineno - 1 if e.lineno else 0
+            start = max(0, error_line - 2)
+            end = min(len(lines), error_line + 3)
+            context = "\n".join(f"{i + 1}: {lines[i]}" for i in range(start, end))
+            raise ValueError(
+                f"Failed to parse Claude's response as JSON: {e}\nContext:\n{context}"
+            ) from e
+        return self._build_itinerary(data, source_file)
+
     def _extract_text_from_pdf(self, file_path: Path) -> str:
         """Extract text content from a PDF file."""
         text_parts = []
@@ -207,34 +282,9 @@ class ItineraryParser:
         """Use Claude to extract structured data from itinerary text."""
         response_text = self.llm.call_api(
             system_prompt="",
-            messages=[{"role": "user", "content": EXTRACTION_PROMPT + text}],
+            messages=[{"role": "user", "content": _build_extraction_prompt() + text}],
         )
-
-        # Extract JSON from response (handle markdown code blocks)
-        if "```json" in response_text:
-            json_str = response_text.split("```json")[1].split("```")[0].strip()
-        elif "```" in response_text:
-            json_str = response_text.split("```")[1].split("```")[0].strip()
-        else:
-            json_str = response_text.strip()
-
-        # Fix common JSON issues like trailing commas
-        json_str = fix_json_string(json_str)
-
-        try:
-            data = json.loads(json_str)
-        except json.JSONDecodeError as e:
-            # Try to show context around the error
-            lines = json_str.split("\n")
-            error_line = e.lineno - 1 if e.lineno else 0
-            start = max(0, error_line - 2)
-            end = min(len(lines), error_line + 3)
-            context = "\n".join(f"{i + 1}: {lines[i]}" for i in range(start, end))
-            raise ValueError(
-                f"Failed to parse Claude's response as JSON: {e}\nContext:\n{context}"
-            ) from e
-
-        return self._build_itinerary(data, source_file)
+        return self._parse_response_text(response_text, source_file)
 
     def _build_itinerary(self, data: dict, source_file: str) -> Itinerary:
         """Build an Itinerary object from parsed data."""

--- a/agents/itinerary/templates/trips.html
+++ b/agents/itinerary/templates/trips.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/categories.css">
     <link rel="stylesheet" href="/static/css/trips.css?v=14">
-    <link rel="stylesheet" href="/static/css/trips-actions.css?v=1">
+    <link rel="stylesheet" href="/static/css/trips-actions.css?v=2">
     <link rel="stylesheet" href="/static/css/trips-share-map.css?v=1">
 </head>
 <body>
@@ -40,6 +40,7 @@
             <li><strong>Paste a Google Maps directions link</strong> to import a route with stops.</li>
             <li><strong>Create from scratch</strong> by chatting with the planner.</li>
         </ul>
+        <p style="margin-bottom: 10px;">A trip can hold many bookings. Open any trip to add more flights, hotels, or notes via its <strong>Upload Plan</strong> button.</p>
         <button class="trips-intro-got-it" id="trips-intro-got-it">Got it</button>
     </div>
 
@@ -54,6 +55,9 @@
                 </button>
                 <p class="supported-formats">PDF, Word, images, text, HTML, email, ICS, JSON, Excel</p>
                 <input type="file" id="upload-input" class="upload-input" accept=".pdf,.txt,.png,.jpg,.jpeg,.html,.htm,.eml,.ics,.json,.xlsx,.xls,.docx">
+                <p class="upload-existing-hint">
+                    Each upload creates a new trip. To add a flight or hotel to an existing trip, open the trip and use its <strong>Upload Plan</strong> button.
+                </p>
             </div>
 
             <div class="url-import-section">
@@ -152,7 +156,7 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="/static/js/main.js?v=7"></script>
     <script src="/static/js/archive.js?v=1"></script>
-    <script src="/static/js/upload.js?v=9"></script>
+    <script src="/static/js/upload.js?v=12"></script>
     <script src="/static/js/trips.js?v=10"></script>
 </body>
 </html>

--- a/agents/pages/routes.py
+++ b/agents/pages/routes.py
@@ -29,6 +29,72 @@ def _html(content: str) -> Response:
     return Response(content, mimetype="text/html")
 
 
+# Status used for "trip exists but is no longer publicly shared." 410 Gone is
+# the right semantic: the resource was here, the owner pulled it. 404 would
+# have implied it never existed.
+_PRIVATE_TRIP_STATUS = 410
+
+
+def _trip_not_available_response(link: str, reason: str) -> Response:
+    """Render a friendly "this trip isn't available" page.
+
+    Two reasons handled:
+      - "missing": the link doesn't match any trip in the DB.
+      - "private": a trip with that link exists but isn't public, and the
+        viewer isn't logged in as the owner.
+
+    The previous behavior was a bare 404 string, which made shared links
+    look broken when in fact the owner had just toggled the trip private.
+    """
+    is_private = reason == "private"
+    title = "This trip isn't public" if is_private else "Trip not found"
+    headline = (
+        "This trip isn't shared publicly anymore."
+        if is_private
+        else "We couldn't find a trip at this link."
+    )
+    detail = (
+        "If you're the trip owner, log in and toggle the lock icon on the trip "
+        "card to share it again."
+        if is_private
+        else "The link may be mistyped, or the trip may have been deleted."
+    )
+    nav = get_nav_html(active_page="")
+    body = f"""<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8"><title>{title} - Libertas</title>
+<link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+<link rel="stylesheet" href="/static/css/main.css?v=14">
+<style>
+.unavailable {{ max-width: 560px; margin: 80px auto; padding: 40px 32px; background: #fff;
+  border-radius: 12px; box-shadow: 0 2px 20px rgba(0,0,0,0.08); text-align: center; }}
+.unavailable i {{ font-size: 3rem; color: #667eea; margin-bottom: 16px; }}
+.unavailable h1 {{ font-size: 1.4rem; color: #1a1a2e; margin: 0 0 12px; }}
+.unavailable p {{ color: #555; line-height: 1.5; margin: 0 0 14px; }}
+.unavailable .actions {{ margin-top: 24px; display: flex; gap: 12px; justify-content: center; }}
+.unavailable .btn {{ display: inline-flex; align-items: center; gap: 6px; padding: 10px 18px;
+  background: #667eea; color: #fff; border-radius: 8px; text-decoration: none; font-size: 0.95rem; }}
+.unavailable .btn.secondary {{ background: #f0f1ff; color: #4a5fd6; }}
+.unavailable .btn:hover {{ filter: brightness(0.95); }}
+.unavailable .link-tag {{ font-family: monospace; font-size: 0.85rem; color: #888;
+  background: #f5f5f5; padding: 4px 8px; border-radius: 4px; word-break: break-all; }}
+</style></head><body>
+{nav}
+<div class="unavailable">
+<i class="fas fa-{"lock" if is_private else "compass"}"></i>
+<h1>{headline}</h1>
+<p>{detail}</p>
+<p><span class="link-tag">{link}</span></p>
+<div class="actions">
+<a href="/" class="btn">Home</a>
+<a href="/trips.html" class="btn secondary">My trips</a>
+</div>
+</div>
+</body></html>"""
+    return Response(body, mimetype="text/html", status=_PRIVATE_TRIP_STATUS if is_private else 404)
+
+
 @pages_bp.get("/")
 @pages_bp.get("/index.html")
 def home():
@@ -135,7 +201,11 @@ def trip_html(trip_name: str):
             trip = db.get_trip_by_link(owner_id, link)
 
     if not trip:
-        return "Trip not found", 404
+        # Distinguish "trip never existed" from "trip exists but is private now"
+        # so a stale shared link gets a friendly explanation, not a hard 404.
+        existing_owner = owner_id or db.get_trip_owner(link)
+        reason = "private" if existing_owner else "missing"
+        return _trip_not_available_response(link, reason)
 
     # Determine viewer context, used by web_view to render the right header buttons
     is_authenticated = user_id is not None
@@ -209,15 +279,14 @@ def recommendation_view(rec_name: str):
     # Find the trip by link (any owner)
     owner_id = db.get_trip_owner(link)
     if owner_id is None:
-        return "Not found", 404
+        return _trip_not_available_response(link, "missing")
 
     trip = db.get_trip_by_link(owner_id, link)
     if not trip:
-        return "Not found", 404
+        return _trip_not_available_response(link, "missing")
 
-    # Must be public
     if not trip.get("is_public"):
-        return "Not found", 404
+        return _trip_not_available_response(link, "private")
 
     itinerary_data = trip.get("itinerary_data") or {}
     if isinstance(itinerary_data, str):
@@ -241,11 +310,13 @@ def writeup_view(rec_name: str):
 
     owner_id = db.get_trip_owner(link)
     if owner_id is None:
-        return "Not found", 404
+        return _trip_not_available_response(link, "missing")
 
     trip = db.get_trip_by_link(owner_id, link)
-    if not trip or not trip.get("is_public"):
-        return "Not found", 404
+    if not trip:
+        return _trip_not_available_response(link, "missing")
+    if not trip.get("is_public"):
+        return _trip_not_available_response(link, "private")
 
     itinerary_data = trip.get("itinerary_data") or {}
     if isinstance(itinerary_data, str):

--- a/static/css/create-content.css
+++ b/static/css/create-content.css
@@ -406,3 +406,38 @@
     padding: 4px 8px;
 }
 .trip-tools-hint-close:hover { color: #1a1a2e; }
+
+/* Drag-drop discoverability tip, sits above Day 1 in the itinerary view.
+   Dismissible (libertas_seen_dragdrop_tip in localStorage). The
+   [hidden] override is needed because display:flex below would otherwise
+   beat the browser default [hidden] { display: none } rule. */
+.dragdrop-tip[hidden] { display: none; }
+.dragdrop-tip {
+    position: relative;
+    margin: 0 0 14px;
+    padding: 10px 36px 10px 14px;
+    background: #f0f1ff;
+    border: 1px solid #c7c9f7;
+    border-left: 4px solid #667eea;
+    border-radius: 8px;
+    color: #1a1a2e;
+    font-size: 0.88rem;
+    line-height: 1.4;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.dragdrop-tip i { color: #f0c674; }
+.dragdrop-tip strong { color: #4a5fd6; }
+.dragdrop-tip-close {
+    position: absolute;
+    top: 4px;
+    right: 8px;
+    background: transparent;
+    border: none;
+    color: #888a96;
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+}
+.dragdrop-tip-close:hover { color: #1a1a2e; }

--- a/static/css/trips-actions.css
+++ b/static/css/trips-actions.css
@@ -54,6 +54,22 @@
     margin-bottom: 0;
 }
 
+/* Hint that imports create new trips, with a pointer to the
+   add-to-existing-trip flow. Fixes Gene's "I didn't know I could do
+   that" feedback (issue #57). */
+.upload-area .upload-existing-hint {
+    font-size: 0.78rem;
+    color: #666;
+    background: #f0f1ff;
+    border-left: 3px solid #667eea;
+    padding: 8px 12px;
+    margin-top: 14px;
+    margin-bottom: 0;
+    border-radius: 6px;
+    text-align: left;
+    line-height: 1.4;
+}
+
 .upload-btn {
     display: inline-flex;
     align-items: center;

--- a/static/js/create.js
+++ b/static/js/create.js
@@ -97,6 +97,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (tripLink) {
         // Load existing trip
         loadTrip(tripLink);
+        _maybeShowPostImportBanner();
+        _wireDragDropTip();
     } else {
         // Show create dialog for new trip
         showCreateDialog();
@@ -106,6 +108,60 @@ document.addEventListener('DOMContentLoaded', () => {
     initChat();
     initDragDrop();
 });
+
+/**
+ * Show the drag-drop discoverability tip above Day 1 unless the user has
+ * dismissed it before (libertas_seen_dragdrop_tip in localStorage).
+ * Persistent (no auto-dismiss) so people who scroll back later can still
+ * notice it. The X removes it and remembers.
+ */
+function _wireDragDropTip() {
+    const tip = document.getElementById('dragdrop-tip');
+    if (!tip) return;
+    let seen = false;
+    try { seen = localStorage.getItem('libertas_seen_dragdrop_tip') === '1'; } catch (e) {}
+    if (seen) return;
+    tip.removeAttribute('hidden');
+    document.getElementById('dragdrop-tip-close')?.addEventListener('click', () => {
+        // Remove instead of toggling [hidden] because .dragdrop-tip uses
+        // display:flex, which overrides the browser default [hidden]
+        // styling. tip.remove() is unambiguous.
+        tip.remove();
+        try { localStorage.setItem('libertas_seen_dragdrop_tip', '1'); } catch (e) {}
+    });
+}
+
+/**
+ * If the user just arrived here from /trips after importing a file, show a
+ * banner pointing at the Upload Plan button so they discover they can keep
+ * adding to this trip. Triggered by the libertas_just_imported flag set in
+ * upload.js. Cleared once shown so a refresh doesn't repeat it.
+ */
+function _maybeShowPostImportBanner() {
+    let flagged = false;
+    try {
+        flagged = sessionStorage.getItem('libertas_just_imported') === '1';
+        if (flagged) sessionStorage.removeItem('libertas_just_imported');
+    } catch (e) {}
+    if (!flagged) return;
+
+    if (document.getElementById('post-import-banner')) return;
+    const banner = document.createElement('div');
+    banner.id = 'post-import-banner';
+    banner.className = 'post-explore-banner';  // reuse existing style
+    banner.innerHTML = (
+        '<i class="fas fa-check-circle"></i> ' +
+        'Trip imported. To add another flight or hotel, ' +
+        '<strong>drop another file anywhere on this page</strong>. ' +
+        '<span class="post-explore-back" style="cursor:pointer">Got it</span>'
+    );
+    document.body.appendChild(banner);
+    banner.addEventListener('click', () => banner.remove());
+    setTimeout(() => {
+        if (banner.parentNode) banner.classList.add('fading');
+    }, 7000);
+    setTimeout(() => banner.remove(), 8000);
+}
 
 /**
  * If the user got here from Explore's "Add to trip → New trip" flow, the

--- a/static/js/upload.js
+++ b/static/js/upload.js
@@ -217,7 +217,18 @@ function promptForTripName(suggestedName, link) {
     input.focus();
     input.select();
 
-    // Handle save
+    // After import we send the user straight into the trip editor instead
+    // of reloading the trips list. Lets them see what was imported and
+    // add more items in one continuous flow (per Gene's feedback, where
+    // a stop on /trips made him think each upload was a separate trip).
+    const goToEditor = () => {
+        // Flag the next page load so the editor can show a "you just
+        // imported, here's how to add more" banner. sessionStorage clears
+        // when the tab closes so it doesn't haunt future visits.
+        try { sessionStorage.setItem('libertas_just_imported', '1'); } catch (e) {}
+        window.location.href = `/create.html?edit=${encodeURIComponent(link)}`;
+    };
+
     const saveTrip = () => {
         const newName = input.value.trim();
         overlay.remove();
@@ -229,25 +240,25 @@ function promptForTripName(suggestedName, link) {
                 body: JSON.stringify({ link: link, newTitle: newName })
             })
             .then(response => response.json())
-            .then(data => {
-                showStatus('success', `Trip saved as "${newName}"`);
-                setTimeout(() => window.location.reload(), 1500);
+            .then(() => {
+                showStatus('success', `Trip saved as "${newName}". Opening editor...`);
+                setTimeout(goToEditor, 800);
             })
             .catch(() => {
-                showStatus('success', `Trip imported as "${suggestedName}"`);
-                setTimeout(() => window.location.reload(), 1500);
+                showStatus('success', `Trip imported as "${suggestedName}". Opening editor...`);
+                setTimeout(goToEditor, 800);
             });
         } else {
-            showStatus('success', `Trip "${suggestedName}" imported successfully!`);
-            setTimeout(() => window.location.reload(), 1500);
+            showStatus('success', `Trip "${suggestedName}" imported. Opening editor...`);
+            setTimeout(goToEditor, 800);
         }
     };
 
-    // Handle cancel (use suggested name)
+    // Handle cancel (use suggested name, still go to editor)
     const useSuggested = () => {
         overlay.remove();
-        showStatus('success', `Trip "${suggestedName}" imported successfully!`);
-        setTimeout(() => window.location.reload(), 1500);
+        showStatus('success', `Trip "${suggestedName}" imported. Opening editor...`);
+        setTimeout(goToEditor, 800);
     };
 
     document.getElementById('modal-save').addEventListener('click', saveTrip);

--- a/tests/test_upload_handlers.py
+++ b/tests/test_upload_handlers.py
@@ -1,0 +1,101 @@
+"""Tests for upload handler entry points.
+
+The /trips upload (``upload_file_handler``) and the in-trip upload
+(``upload_plan_handler``) are two separate code paths that take different
+file types. These unit tests pin down which extensions each path supports
+without requiring a live LLM, the LLM call is mocked.
+
+Backstory: a 2517-line handler.py was split into focused modules (commit
+1ef25bb) and the image-upload branch silently lost its vision-API call.
+PNG uploads started 400-ing on /trips for weeks before a user reported
+it. These tests exist so that can't happen again.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agents.create.upload_handlers import upload_file_handler
+from agents.itinerary.parser import Itinerary
+
+# A real 1x1 transparent PNG, smallest possible. Avoids needing Pillow as
+# a test dep just to generate a valid file header.
+_TINY_PNG_BYTES = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+
+
+@pytest.fixture
+def stub_itinerary():
+    """Empty Itinerary stub for parser mocks."""
+    return Itinerary(title="Test Trip", items=[])
+
+
+def test_png_upload_routes_to_vision_parser(stub_itinerary, tmp_path, app):
+    """Regression: PNG goes through ``parser.parse_image``, not parse_file.
+
+    If someone refactors and accidentally drops the image branch again,
+    this test fails immediately instead of waiting for a friend to email.
+    """
+    with (
+        patch("agents.itinerary.parser.ItineraryParser") as parser_cls,
+        patch("agents.itinerary.web_view.ItineraryWebView") as web_view_cls,
+        patch("agents.itinerary.geocoding_worker.queue_geocoding"),
+        patch("agents.create.upload_handlers.db.add_trip", return_value=1),
+    ):
+        parser_cls.return_value.parse_image.return_value = stub_itinerary
+        web_view_cls.return_value.generate.return_value = None
+
+        result, status = upload_file_handler(
+            user_id=1,
+            file_data=_TINY_PNG_BYTES,
+            filename="boarding_pass.png",
+            output_dir=tmp_path,
+        )
+
+        assert status == 200, f"PNG upload returned {status}: {result}"
+        assert result.get("success") is True
+        # The whole point: vision path was used, not the text path.
+        parser_cls.return_value.parse_image.assert_called_once()
+        parser_cls.return_value.parse_file.assert_not_called()
+
+
+def test_jpg_upload_also_uses_vision_parser(stub_itinerary, tmp_path, app):
+    """Same regression check for JPG. extract_file_content treats jpg/jpeg
+    the same way; this just pins the behavior."""
+    with (
+        patch("agents.itinerary.parser.ItineraryParser") as parser_cls,
+        patch("agents.itinerary.web_view.ItineraryWebView") as web_view_cls,
+        patch("agents.itinerary.geocoding_worker.queue_geocoding"),
+        patch("agents.create.upload_handlers.db.add_trip", return_value=1),
+    ):
+        parser_cls.return_value.parse_image.return_value = stub_itinerary
+        web_view_cls.return_value.generate.return_value = None
+
+        # Re-use the PNG bytes; the dispatch is purely on file extension,
+        # and avoiding a real JPG keeps the test data minimal.
+        result, status = upload_file_handler(
+            user_id=1,
+            file_data=_TINY_PNG_BYTES,
+            filename="ticket.jpg",
+            output_dir=tmp_path,
+        )
+
+        assert status == 200, f"JPG upload returned {status}: {result}"
+        parser_cls.return_value.parse_image.assert_called_once()
+
+
+def test_unsupported_extension_returns_400(tmp_path, app):
+    """Confirm the supported-extension gate still rejects junk."""
+    result, status = upload_file_handler(
+        user_id=1,
+        file_data=b"<exe>",
+        filename="malware.exe",
+        output_dir=tmp_path,
+    )
+    assert status == 400
+    assert "Unsupported" in result.get("error", "")


### PR DESCRIPTION
Friend feedback from Gene Chang (#54 spawned merge-trips ask) and Bryan Gillette (#55 stuck-map, #56 calendar export) drove this branch. None of the items here required a redesign; they were small UX tweaks plus two real regressions.

## User-visible

- **Drag-drop discoverability tip** above Day 1 in the trip editor, dismissible. Tells users they can drop another file anywhere on the page or use Upload Plan.
- **Post-import banner** when arriving at the editor from a fresh /trips upload (sessionStorage flag).
- **Redirect to editor after import** instead of reloading /trips. Keeps the "what did I just import" moment in front of the user.
- **/trips upload area hint**: "Each upload creates a new trip. To add to an existing trip, open it and use Upload Plan."
- **First-time intro card** gains a multi-booking line so the same idea lands on first arrival.
- **Friendlier 410 page** when ``/<trip>.html``, ``/r/<trip>``, or ``/w/<trip>`` resolves to a trip that exists but is private. Distinguishes "never existed" from "owner pulled it" so stale shared links don't look broken.
- **Share modal labels** reworded ("Share full itinerary" / "Share as recommendation list" / "Share as written narrative").

## Bug fixes

- **PNG (and JPG) uploads on /trips were 400-ing.** The handler-split refactor in 1ef25bb silently dropped the vision-API branch. Restored via ``parser.parse_image()`` and a regression test in ``tests/test_upload_handlers.py`` that pins the routing.
- **"Wed, 20MAY" parsed as 2020 instead of 2026.** The static extraction prompt had no year-resolution guidance, so the LLM picked whichever year matched the weekday. Prompt now renders fresh per call with today's date and an explicit upcoming/past rule.

## Process

- **CLAUDE.md "Testing" section** now requires preserving coverage during refactors. The PNG regression is the cited cautionary tale.
- **scripts/check_users.sh** (added earlier in the branch) - dumps signup + recent-trip activity from the prod ``/api/debug`` endpoint. Reads SECRET_KEY from ``~/.profile``.

Closes #49 (discoverability follow-ups). Issues #54, #55, #56, #57, #58, #59 spawned from this work and are tracked separately.

## Test plan
- [ ] Drop a PNG on /trips, confirm trip is created (regression #1)
- [ ] Upload a flight confirmation with weekday-only dates ("Wed, 20MAY"), confirm year resolves to 2026 (regression #2)
- [ ] Drop a file on /trips, see the redirect to editor and the post-import banner
- [ ] Visit /create.html?edit=<any> on first load, see the dismissible drag-drop tip above Day 1
- [ ] Visit /w/<private-trip>, see the friendly "trip isn't public" page
- [ ] CI: ruff, file-size, em-dash, marketing-copy, tests all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)