### PR TITLE
Fix red-eye flight ICS export (DTEND was before DTSTART)

### DIFF
--- a/agents/trips/ics.py
+++ b/agents/trips/ics.py
@@ -115,9 +115,25 @@ def generate_ics(export_data: dict, link: str) -> str:
                         day_date, datetime.min.time().replace(hour=start_hm[0], minute=start_hm[1])
                     )
                     end_hm = _parse_hhmm(item_end_time) if item_end_time else None
+
+                    # End-date resolution priority:
+                    #   1. explicit item["end_date"] (hotels, car rentals)
+                    #   2. inferred next-day if end_time < start_time
+                    #      (red-eye flights, late-night dinners that go past midnight)
+                    #   3. same day as start
+                    end_date_str = item.get("end_date")
+                    end_date = day_date
+                    if end_date_str:
+                        try:
+                            end_date = _date.fromisoformat(end_date_str)
+                        except ValueError:
+                            pass
+                    elif end_hm and (end_hm[0], end_hm[1]) < (start_hm[0], start_hm[1]):
+                        end_date = day_date + timedelta(days=1)
+
                     end = (
                         datetime.combine(
-                            day_date,
+                            end_date,
                             datetime.min.time().replace(hour=end_hm[0], minute=end_hm[1]),
                         )
                         if end_hm

--- a/tests/test_calendar_export.py
+++ b/tests/test_calendar_export.py
@@ -256,3 +256,57 @@ class TestGeneratedIcsFormat:
             "trip.html",
         )
         assert "Floating thing" not in ics
+
+    def test_red_eye_flight_arrives_next_day(self):
+        """Regression: a flight where end_time < start_time used to emit
+        DTEND on the same calendar date as DTSTART, producing DTEND <
+        DTSTART. Apple/Outlook silently drop those events. The exporter
+        now bumps end_date forward by one day in that case."""
+        ics = generate_ics(
+            self._export_payload(
+                [
+                    {
+                        "date": "2026-06-21",
+                        "items": [
+                            {
+                                "title": "DL 452 SEA -> JFK",
+                                "category": "flight",
+                                "time": "22:20",
+                                "end_time": "06:34",
+                            }
+                        ],
+                    }
+                ]
+            ),
+            "trip.html",
+        )
+        # Departure on Jun 21 22:20
+        assert "20260621T222000" in ics
+        # Arrival on Jun 22 06:34, NOT Jun 21
+        assert "20260622T063400" in ics
+
+    def test_explicit_end_date_is_honored(self):
+        """Multi-day items (hotels, car rentals) carry their own end_date.
+        The exporter should use it directly."""
+        ics = generate_ics(
+            self._export_payload(
+                [
+                    {
+                        "date": "2026-06-10",
+                        "items": [
+                            {
+                                "title": "Marriott Seattle",
+                                "category": "hotel",
+                                "time": "16:00",
+                                "end_time": "11:00",
+                                "end_date": "2026-06-15",
+                            }
+                        ],
+                    }
+                ]
+            ),
+            "trip.html",
+        )
+        # Check-in 2026-06-10 16:00, check-out 2026-06-15 11:00
+        assert "20260610T160000" in ics
+        assert "20260615T110000" in ics


### PR DESCRIPTION
Fixes calendar export bug found by Bryan-style real-world data on prod.

## Symptom

A round-trip with a red-eye return flight exported correctly to ``.ics`` (both VEVENTs present), but Apple Calendar and Outlook silently dropped the return event. The trip showed only the outbound leg.

## Root cause

DL 452 SEA → JFK departed 22:20 Jun 21, arrived 06:34 **Jun 22**. The exporter put DTEND on the same calendar date as DTSTART regardless:

\`\`\`
DTSTART:20260621T222000
DTEND:20260621T063400   ← BEFORE departure
\`\`\`

Calendar apps see DTEND < DTSTART and drop the event.

## Fix

End-date resolution priority is now:

1. Explicit ``item["end_date"]`` (hotels, car rentals carry it)
2. Inferred next-day if ``end_time < start_time`` (red-eye, late dinner)
3. Same day as start (default for normal events)

Two new tests pin both branches. Existing 19 calendar tests still pass.

## Test plan
- [ ] Re-download .ics for ``uw_graduation_jun_2026.html`` and confirm the return flight DTEND is on Jun 22, not Jun 21
- [ ] Reload the subscribed calendar (Apple/Outlook) and confirm both legs render
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)