### PR TITLE
Let article-style PDFs go to the ideas pile

### DIFF
--- a/agents/create/templates/create.html
+++ b/agents/create/templates/create.html
@@ -370,7 +370,7 @@
     <script src="/static/js/create.js?v=58"></script>
     <script src="/static/js/create-render.js?v=2"></script>
     <script src="/static/js/create-items.js?v=3"></script>
-    <script src="/static/js/create-upload.js?v=3"></script>
+    <script src="/static/js/create-upload.js?v=4"></script>
     <script src="/static/js/create-save.js?v=4"></script>
     <script src="/static/js/create-chat.js?v=1"></script>
     <script src="/static/js/create-dragdrop.js?v=1"></script>

--- a/agents/create/upload_handlers.py
+++ b/agents/create/upload_handlers.py
@@ -99,6 +99,16 @@ IMPORTANT: For DAY-BY-DAY NARRATIVE ITINERARIES (expedition, adventure, tour iti
 - Use category "flight" for flights
 - Include the day number from "Day 1", "Day 2", etc.
 
+IMPORTANT: For ARTICLES, BLOG POSTS, GUIDES, or RECOMMENDATION LISTS (no bookings, no concrete dates):
+- This is the "ideas-pile" case. Extract every named place worth visiting as a separate item.
+- Each restaurant, hotel, neighborhood, attraction, museum, bar, viewpoint, beach, market, etc. mentioned by name becomes one item.
+- Set date, time, end_time, end_date, day to null, these will land in the user's Ideas pile to schedule later.
+- Use the right category (meal for restaurants/cafes/bars, hotel for accommodations, attraction for museums/landmarks, activity for hiking/tours, etc.).
+- Put the city or neighborhood in location.
+- Put a one-line description in notes (what makes this place worth visiting, per the article).
+- Skip generic guidance like "try the local cuisine" or "stay near the center", we want named places only.
+- An article with 10 places mentioned should return 10 items, not 0.
+
 Return your response as a JSON array of items. Example:
 ```json
 [

--- a/static/js/create-upload.js
+++ b/static/js/create-upload.js
@@ -87,7 +87,16 @@ async function handleDroppedFile(file) {
         } else if (data.error) {
             addChatMessage('assistant', `Could not extract travel items from **${file.name}**:\n\n${data.error}`);
         } else {
-            addChatMessage('assistant', `No travel items found in **${file.name}**. Try uploading a booking confirmation, itinerary, or ticket.`);
+            // Empty extraction is rare now (the prompt covers articles + lists),
+            // but fall through gracefully if it happens. Tell the user what
+            // worked best historically without making them feel like the upload
+            // path is broken.
+            addChatMessage(
+                'assistant',
+                `I couldn't pull anything actionable out of **${file.name}**. ` +
+                `Try a booking confirmation, an article that names specific places, ` +
+                `or paste the trip details into chat directly.`
+            );
         }
     } catch (error) {
         console.error('Drop upload error:', error);


### PR DESCRIPTION
## What

When a user drops a PDF travel-recommendations article (no dates, no bookings) onto **Upload Plan**, the LLM's extraction returned 0 items and the UI said "No travel items found, try a booking confirmation." Dead-end for a real use case: paywalled articles, blog posts, "10 best places in Lisbon" lists, etc.

## Fix

The extraction prompt was tuned for confirmations and narrative itineraries; it didn't tell the LLM "extract every named place even if there are no dates." Added an explicit ARTICLES / BLOG POSTS / RECOMMENDATION LISTS section that produces date-less items per named place. Each lands in the Ideas pile naturally because date and day are null.

Also softened the empty-result frontend copy so the rare case where extraction returns 0 items doesn't read like a broken upload.

## Test plan
- [ ] Drop the user's "Top 10 restaurants in X" PDF onto an existing trip's Upload Plan. Expect 10 items in the Ideas pile, no dates.
- [ ] Drop a regular booking confirmation. Expect normal behavior (items with dates pinned to days).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)