### PR TITLE
Stop truncating long PDF uploads at 10k characters

### DIFF
--- a/agents/create/upload_handlers.py
+++ b/agents/create/upload_handlers.py
@@ -138,8 +138,10 @@ If you cannot extract any travel items, return an empty array: []
 Only return the JSON array, no other text."""
 
     try:
-        # 4096 tokens accommodates large trips (20+ items); 2048 caused truncation
-        llm = make_llm(model=SONNET, max_tokens=4096)
+        # 16k output tokens covers very long itineraries (50+ items, full
+        # day-by-day Backroads-style PDFs). Previous 4096 cap silently
+        # truncated the JSON, dropping later days.
+        llm = make_llm(model=SONNET, max_tokens=16384)
 
         if image_data:
             messages = [
@@ -162,10 +164,17 @@ Only return the JSON array, no other text."""
                 }
             ]
         else:
+            # 100k chars of input ~ 25k tokens, well under Sonnet's 200k
+            # context. Previous 10k char cap was a defensive holdover from
+            # smaller-context days and silently dropped most of a 16-page
+            # itinerary on real Backroads/G Adventures PDFs.
             messages = [
                 {
                     "role": "user",
-                    "content": f"Extract travel items from this document (filename: {filename}):\n\n{content_for_llm[:10000]}",
+                    "content": (
+                        f"Extract travel items from this document "
+                        f"(filename: {filename}):\n\n{content_for_llm[:100_000]}"
+                    ),
                 }
             ]
 

--- a/tests/test_upload_handlers.py
+++ b/tests/test_upload_handlers.py
@@ -89,6 +89,45 @@ def test_jpg_upload_also_uses_vision_parser(stub_itinerary, tmp_path, app):
         parser_cls.return_value.parse_image.assert_called_once()
 
 
+def test_upload_plan_does_not_truncate_long_text():
+    """Regression: a 16-page Peru itinerary (~40k chars) was being sliced
+    to 10k chars before going to the LLM, so the trip silently stopped
+    at day 5 or 6. Confirm the cap is generous enough that a realistic
+    long document goes through intact."""
+    from unittest.mock import MagicMock, patch
+
+    from agents.create.upload_handlers import upload_plan_handler
+
+    # Use a distinct tail marker so we can prove the LAST chunk made it
+    # through. A repeating string would falsely pass even with truncation
+    # because the tail would also appear in the head.
+    filler = "Day filler content for the middle of the itinerary. " * 800
+    long_text = filler + "UNIQUE_TAIL_MARKER_LAST_DAY_OF_TRIP"
+    fake_response = MagicMock()
+    fake_response.content = [MagicMock(text="[]")]
+
+    with (
+        patch("agents.create.upload_handlers.extract_file_content") as extract,
+        patch("agents.create.upload_handlers.make_llm") as make_llm,
+    ):
+        extract.return_value = {"text": long_text}
+        llm = make_llm.return_value
+        llm.call_api.return_value = fake_response
+
+        upload_plan_handler(user_id=1, filename="peru.pdf", file_data=b"...", ext="pdf")
+
+        # The user-message content sent to the LLM must contain the unique
+        # tail marker, not just the filler. The previous 10k-char cap dropped
+        # the marker; the new 100k-char cap keeps it.
+        call = llm.call_api.call_args
+        messages = call.kwargs["messages"]
+        sent_content = messages[0]["content"]
+        assert "UNIQUE_TAIL_MARKER_LAST_DAY_OF_TRIP" in sent_content, (
+            "Long-text upload was truncated before reaching the LLM. "
+            "The end of the document is missing."
+        )
+
+
 def test_unsupported_extension_returns_400(tmp_path, app):
     """Confirm the supported-extension gate still rejects junk."""
     result, status = upload_file_handler(


### PR DESCRIPTION
## Symptom

User dropped a 16-page Backroads Peru itinerary PDF and only the first 5-6 days came through. No error message; the rest of the trip was silently dropped.

## Root cause

``upload_plan_handler`` sliced the extracted PDF text to ``[:10000]`` before sending it to the LLM. The Peru PDF was 39,612 chars, so roughly the last 75% of the content never reached Claude.

The 10k cap was a defensive holdover from smaller-context days. Sonnet's window is 200k.

## Fix

- Input cap: 10,000 → 100,000 chars
- Output ``max_tokens``: 4096 → 16384 (large itineraries emit large JSON; the old cap could silently truncate the response)

## Test plan
- [ ] Re-upload the Peru Backroads PDF and confirm all 14 days import
- [ ] Test a normal short confirmation PDF still works
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)