### PR TITLE
Add per-user all-trips calendar feed

### DIFF
--- a/agents/trips/ics.py
+++ b/agents/trips/ics.py
@@ -47,6 +47,128 @@ def verify_subscribe_token(user_id: int, link: str, provided: str) -> bool:
     return hmac.compare_digest(expected, provided)
 
 
+def user_calendar_token(user_id: int) -> str:
+    """Build a deterministic per-user HMAC token for the all-trips feed.
+
+    Same HMAC approach as calendar_subscribe_token but scoped to the user
+    (no trip link), so one URL covers all their published trips. The "user-cal"
+    prefix prevents token reuse between the two surfaces.
+    """
+    secret = os.environ.get("SECRET_KEY", "")
+    if not secret:
+        raise RuntimeError("SECRET_KEY not set, cannot generate user calendar token")
+    payload = f"user-cal:{user_id}".encode()
+    digest = hmac.new(secret.encode(), payload, hashlib.sha256).digest()
+    return digest.hex()[:32]
+
+
+def verify_user_calendar_token(user_id: int, provided: str) -> bool:
+    """Constant-time check of a user calendar token."""
+    expected = user_calendar_token(user_id)
+    return hmac.compare_digest(expected, provided)
+
+
+def generate_ics_multi(trips: list[dict]) -> str:
+    """Generate a single ICS feed containing all events from multiple trips.
+
+    Each trip dict must have ``title``, ``link``, and ``itinerary_data``
+    (already parsed from JSON). Only days with a ``date`` are included;
+    items without a date on their day are skipped (same rule as
+    generate_ics).
+    """
+    cal = Calendar()
+    cal.add("VERSION", "2.0")
+    cal.add("PRODID", "-//Libertas Travel//Trip Planner//EN")
+    cal.add("CALSCALE", "GREGORIAN")
+    cal.add("METHOD", "PUBLISH")
+    cal.add("X-WR-CALNAME", "Libertas Travel")
+
+    now_utc = datetime.utcnow()
+
+    for trip in trips:
+        link = trip.get("link", "unknown")
+        itinerary_data = trip.get("itinerary_data") or {}
+        days = itinerary_data.get("days", [])
+        event_count = 0
+
+        for day in days:
+            day_date_str = day.get("date")
+            if not day_date_str:
+                continue
+            try:
+                day_date = _date.fromisoformat(day_date_str)
+            except ValueError:
+                continue
+
+            for item in day.get("items", []):
+                event_count += 1
+                item_title = item.get("title", "Activity")
+                item_time = item.get("time")
+                item_end_time = item.get("end_time")
+                item_location = item.get("location", "")
+                item_notes = item.get("notes", "")
+                item_category = item.get("category", "activity")
+                item_website = item.get("website", "")
+
+                event = Event()
+                event.add("UID", f"{link}-{day_date_str}-{event_count}@libertas.app")
+                event.add("DTSTAMP", now_utc)
+                event.add("SUMMARY", item_title)
+
+                if item_time:
+                    start_hm = _parse_hhmm(item_time)
+                    if start_hm is None:
+                        event.add("DTSTART", day_date)
+                        event.add("DTEND", day_date)
+                    else:
+                        start = datetime.combine(
+                            day_date,
+                            datetime.min.time().replace(hour=start_hm[0], minute=start_hm[1]),
+                        )
+                        end_hm = _parse_hhmm(item_end_time) if item_end_time else None
+
+                        end_date_str = item.get("end_date")
+                        end_date = day_date
+                        if end_date_str:
+                            try:
+                                end_date = _date.fromisoformat(end_date_str)
+                            except ValueError:
+                                pass
+                        elif end_hm and (end_hm[0], end_hm[1]) < (start_hm[0], start_hm[1]):
+                            end_date = day_date + timedelta(days=1)
+
+                        end = (
+                            datetime.combine(
+                                end_date,
+                                datetime.min.time().replace(hour=end_hm[0], minute=end_hm[1]),
+                            )
+                            if end_hm
+                            else start + timedelta(hours=1)
+                        )
+                        event.add("DTSTART", start)
+                        event.add("DTEND", end)
+                else:
+                    event.add("DTSTART", day_date)
+                    event.add("DTEND", day_date)
+
+                if item_location:
+                    event.add("LOCATION", item_location)
+
+                desc_parts = []
+                if item_category:
+                    desc_parts.append(f"Category: {item_category.title()}")
+                if item_notes:
+                    desc_parts.append(item_notes)
+                if item_website:
+                    desc_parts.append(f"Website: {item_website}")
+                if desc_parts:
+                    event.add("DESCRIPTION", "\n".join(desc_parts))
+
+                cal.add_component(event)
+
+    return cal.to_ical().decode("utf-8")
+
+
 def _parse_hhmm(value: str) -> tuple[int, int] | None:
     """Parse 'HH:MM' into (hour, minute), or None if malformed."""
     try:

--- a/agents/trips/routes.py
+++ b/agents/trips/routes.py
@@ -13,7 +13,14 @@ import database as db
 from agents.common.flask_utils import json_err, json_ok, require_auth
 from agents.create import handler as create_handler
 from agents.itinerary import geocoding_worker
-from agents.trips.ics import calendar_subscribe_token, generate_ics, verify_subscribe_token
+from agents.trips.ics import (
+    calendar_subscribe_token,
+    generate_ics,
+    generate_ics_multi,
+    user_calendar_token,
+    verify_subscribe_token,
+    verify_user_calendar_token,
+)
 
 trips_bp = Blueprint("trips", __name__)
 
@@ -136,6 +143,51 @@ def calendar_subscribe_url(link: str):
     )
     url = f"{base}/api/trips/{link}/calendar.ics?token={token}"
     return json_ok({"url": url})
+
+
+@trips_bp.get("/api/calendar/subscribe-url")
+@require_auth
+def user_calendar_subscribe_url():
+    """Return a webcal:// URL for the user's all-trips calendar feed.
+
+    The feed covers all published (non-draft) trips that have dates.
+    Uses a user-scoped HMAC token so calendar apps can poll without a session.
+    """
+    token = user_calendar_token(g.user_id)
+    base = (
+        request.host_url.rstrip("/")
+        .replace("http://", "webcal://")
+        .replace("https://", "webcal://")
+    )
+    url = f"{base}/api/calendar/all.ics?user_id={g.user_id}&token={token}"
+    return json_ok({"url": url})
+
+
+@trips_bp.get("/api/calendar/all.ics")
+def user_calendar_feed():
+    """Serve all published trips with dates as a single .ics feed.
+
+    Unauthenticated: validated by a user-scoped HMAC token (same pattern as
+    the per-trip subscribe URL). Calendar apps poll this URL periodically.
+    """
+    from flask import Response
+
+    try:
+        user_id = int(request.args.get("user_id", ""))
+    except (ValueError, TypeError):
+        return json_err("Missing user_id", status=400)
+
+    token = request.args.get("token", "").strip()
+    if not token or not verify_user_calendar_token(user_id, token):
+        return json_err("Invalid token", status=403)
+
+    trips = db.get_published_trips_with_dates(user_id)
+    ics_content = generate_ics_multi(trips)
+    return Response(
+        ics_content,
+        mimetype="text/calendar; charset=utf-8",
+        headers={"Content-Disposition": 'attachment; filename="libertas-trips.ics"'},
+    )
 
 
 @trips_bp.get("/api/trip/<link>/can-edit")

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -31,6 +31,7 @@ from database.trips import (  # noqa: F401
     add_trip,
     delete_trip,
     get_pending_geocoding_trips,
+    get_published_trips_with_dates,
     get_trip_by_link,
     get_trip_owner,
     get_user_trips,

--- a/database/trips.py
+++ b/database/trips.py
@@ -110,6 +110,21 @@ _SQL_SQLITE_SET_TRIP_ARCHIVED = """
     WHERE user_id = ? AND link = ?
 """
 
+# Columns fetched for the multi-trip calendar feed. Minimal: we only need
+# enough to build the ICS and filter by date.
+_CALENDAR_FEED_COLUMNS = ["title", "link", "itinerary_data"]
+
+_SQL_PG_GET_PUBLISHED_TRIPS_WITH_DATES = (
+    f"SELECT {', '.join(_CALENDAR_FEED_COLUMNS)} FROM trips "
+    f"WHERE user_id = %s AND is_draft = FALSE AND itinerary_data IS NOT NULL "
+    f"ORDER BY created_at DESC"
+)
+_SQL_SQLITE_GET_PUBLISHED_TRIPS_WITH_DATES = (
+    f"SELECT {', '.join(_CALENDAR_FEED_COLUMNS)} FROM trips "
+    f"WHERE user_id = ? AND is_draft = 0 AND itinerary_data IS NOT NULL "
+    f"ORDER BY created_at DESC"
+)
+
 
 def get_user_trips(user_id: int) -> list[dict[str, Any]]:
     """Get all trips for a user."""
@@ -309,3 +324,29 @@ def set_trip_archived(user_id: int, link: str, is_archived: bool) -> bool:
         else:
             cursor.execute(_SQL_SQLITE_SET_TRIP_ARCHIVED, (is_archived, user_id, link))
         return cursor.rowcount > 0
+
+
+def get_published_trips_with_dates(user_id: int) -> list[dict[str, Any]]:
+    """Return published (non-draft) trips for a user that have itinerary_data.
+
+    Filters to only trips where itinerary_data contains a start_date so the
+    caller can safely assume date information exists.
+    """
+    with get_db() as conn:
+        cursor = conn.cursor()
+        if USE_POSTGRES:
+            cursor.execute(_SQL_PG_GET_PUBLISHED_TRIPS_WITH_DATES, (user_id,))
+            rows = cursor.fetchall()
+            trips = [dict(zip(_CALENDAR_FEED_COLUMNS, row, strict=False)) for row in rows]
+        else:
+            cursor.execute(_SQL_SQLITE_GET_PUBLISHED_TRIPS_WITH_DATES, (user_id,))
+            rows = cursor.fetchall()
+            trips = []
+            for row in rows:
+                t = dict(row)
+                if t.get("itinerary_data") and isinstance(t["itinerary_data"], str):
+                    t["itinerary_data"] = json.loads(t["itinerary_data"])
+                trips.append(t)
+
+    # Keep only trips that actually have a start_date in the parsed data
+    return [t for t in trips if (t.get("itinerary_data") or {}).get("start_date")]

--- a/tests/test_calendar_export.py
+++ b/tests/test_calendar_export.py
@@ -14,7 +14,14 @@ import os
 
 import pytest
 
-from agents.trips.ics import calendar_subscribe_token, generate_ics, verify_subscribe_token
+from agents.trips.ics import (
+    calendar_subscribe_token,
+    generate_ics,
+    generate_ics_multi,
+    user_calendar_token,
+    verify_subscribe_token,
+    verify_user_calendar_token,
+)
 
 # ---------------------------------------------------------------------------
 # Token roundtrip
@@ -310,3 +317,138 @@ class TestGeneratedIcsFormat:
         # Check-in 2026-06-10 16:00, check-out 2026-06-15 11:00
         assert "20260610T160000" in ics
         assert "20260615T110000" in ics
+
+
+# ---------------------------------------------------------------------------
+# User-scoped calendar token
+# ---------------------------------------------------------------------------
+
+
+class TestUserCalendarToken:
+    def test_token_is_deterministic(self):
+        os.environ["SECRET_KEY"] = "test-secret"
+        assert user_calendar_token(1) == user_calendar_token(1)
+
+    def test_token_differs_per_user(self):
+        os.environ["SECRET_KEY"] = "test-secret"
+        assert user_calendar_token(1) != user_calendar_token(2)
+
+    def test_token_differs_from_per_trip_token(self):
+        # user-cal and calendar namespaces must not collide
+        os.environ["SECRET_KEY"] = "test-secret"
+        assert user_calendar_token(1) != calendar_subscribe_token(1, "")
+
+    def test_verify_accepts_valid_token(self):
+        os.environ["SECRET_KEY"] = "test-secret"
+        token = user_calendar_token(42)
+        assert verify_user_calendar_token(42, token) is True
+
+    def test_verify_rejects_wrong_user(self):
+        os.environ["SECRET_KEY"] = "test-secret"
+        token = user_calendar_token(1)
+        assert verify_user_calendar_token(2, token) is False
+
+    def test_verify_rejects_tampered_token(self):
+        os.environ["SECRET_KEY"] = "test-secret"
+        token = user_calendar_token(1)
+        assert verify_user_calendar_token(1, token + "X") is False
+
+    def test_refuses_when_secret_unset(self):
+        os.environ.pop("SECRET_KEY", None)
+        with pytest.raises(RuntimeError):
+            user_calendar_token(1)
+
+
+# ---------------------------------------------------------------------------
+# generate_ics_multi
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateIcsMulti:
+    def _trip(self, link, title, days):
+        return {"link": link, "title": title, "itinerary_data": {"days": days}}
+
+    def test_merges_events_from_multiple_trips(self):
+        trips = [
+            self._trip(
+                "trip-a.html",
+                "Paris",
+                [
+                    {
+                        "date": "2026-07-01",
+                        "items": [{"title": "Eiffel Tower", "category": "attraction"}],
+                    }
+                ],
+            ),
+            self._trip(
+                "trip-b.html",
+                "Rome",
+                [
+                    {
+                        "date": "2026-08-10",
+                        "items": [{"title": "Colosseum", "category": "attraction"}],
+                    }
+                ],
+            ),
+        ]
+        ics = generate_ics_multi(trips)
+        assert "Eiffel Tower" in ics
+        assert "Colosseum" in ics
+        assert ics.count("BEGIN:VEVENT") == 2
+
+    def test_empty_trips_produces_valid_calendar(self):
+        ics = generate_ics_multi([])
+        assert "BEGIN:VCALENDAR" in ics
+        assert "BEGIN:VEVENT" not in ics
+
+    def test_skips_days_without_date(self):
+        trips = [
+            self._trip(
+                "trip-x.html",
+                "No Dates",
+                [{"items": [{"title": "Ghost event"}]}],
+            )
+        ]
+        ics = generate_ics_multi(trips)
+        assert "Ghost event" not in ics
+
+    def test_calendar_name_is_libertas_travel(self):
+        ics = generate_ics_multi([])
+        assert "Libertas Travel" in ics
+
+
+# ---------------------------------------------------------------------------
+# /api/calendar/subscribe-url and /api/calendar/all.ics routes
+# ---------------------------------------------------------------------------
+
+
+class TestUserCalendarRoutes:
+    def test_subscribe_url_returns_webcal(self, client, app):
+        os.environ["SECRET_KEY"] = "test-secret"
+        resp = client.get("/api/calendar/subscribe-url")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        url = data.get("url", "")
+        assert url.startswith("webcal://")
+        assert "user_id=" in url
+        assert "token=" in url
+        assert "/api/calendar/all.ics" in url
+
+    def test_all_ics_valid_token_returns_calendar(self, client, app):
+        os.environ["SECRET_KEY"] = "test-secret"
+        token = user_calendar_token(1)
+        resp = client.get(f"/api/calendar/all.ics?user_id=1&token={token}")
+        assert resp.status_code == 200
+        assert resp.mimetype.startswith("text/calendar")
+        body = resp.get_data(as_text=True)
+        assert "BEGIN:VCALENDAR" in body
+
+    def test_all_ics_invalid_token_returns_403(self, client, app):
+        os.environ["SECRET_KEY"] = "test-secret"
+        resp = client.get("/api/calendar/all.ics?user_id=1&token=garbage")
+        assert resp.status_code == 403
+
+    def test_all_ics_missing_user_id_returns_400(self, client, app):
+        os.environ["SECRET_KEY"] = "test-secret"
+        resp = client.get("/api/calendar/all.ics?token=anything")
+        assert resp.status_code == 400


### PR DESCRIPTION
Two new endpoints:

- `GET /api/calendar/subscribe-url` - authenticated, returns a `webcal://` URL for the user's all-trips feed
- `GET /api/calendar/all.ics?user_id=N&token=T` - unauthenticated (token auth), serves merged ICS

Only includes published (non-draft) trips that have a start_date. Uses a user-scoped HMAC token (same stateless approach as the per-trip subscribe token - no DB changes needed).

Tests: 36 passing in test_calendar_export.py