### PR TITLE
Add Subscribe button to trips page for all-trips calendar feed

### DIFF
--- a/agents/itinerary/templates/trips.html
+++ b/agents/itinerary/templates/trips.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/categories.css">
-    <link rel="stylesheet" href="/static/css/trips.css?v=14">
+    <link rel="stylesheet" href="/static/css/trips.css?v=15">
     <link rel="stylesheet" href="/static/css/trips-actions.css?v=3">
     <link rel="stylesheet" href="/static/css/trips-share-map.css?v=1">
 </head>
@@ -23,9 +23,14 @@
                 <h1><i class="fas fa-route"></i> My Trips</h1>
                 <p>Itineraries, ideas, and shared trips, all in one list.</p>
             </div>
-            <a href="/create.html" class="new-trip-btn">
-                <i class="fas fa-plus"></i> New Trip
-            </a>
+            <div class="trips-header-actions">
+                <button class="calendar-feed-btn" onclick="subscribeAllTripsCalendar()" title="Subscribe to all trips in your calendar app">
+                    <i class="fas fa-calendar-alt"></i> Subscribe
+                </button>
+                <a href="/create.html" class="new-trip-btn">
+                    <i class="fas fa-plus"></i> New Trip
+                </a>
+            </div>
         </div>
     </div>
 
@@ -165,7 +170,7 @@
     <script src="/static/js/archive.js?v=1"></script>
     <script src="/static/js/upload.js?v=15"></script>
     <script src="/static/js/trips-actions.js?v=1"></script>
-    <script src="/static/js/calendar-export.js?v=3"></script>
+    <script src="/static/js/calendar-export.js?v=4"></script>
     <script src="/static/js/trips.js?v=10"></script>
 </body>
 </html>

--- a/static/css/trips.css
+++ b/static/css/trips.css
@@ -26,6 +26,34 @@
     margin: 0 auto;
 }
 
+.trips-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 20px;
+    flex-wrap: wrap;
+}
+
+.calendar-feed-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: transparent;
+    color: #fff;
+    padding: 10px 20px;
+    border-radius: 25px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    border: 2px solid rgba(255,255,255,0.6);
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.calendar-feed-btn:hover {
+    background: rgba(255,255,255,0.15);
+    border-color: #fff;
+}
+
 .new-trip-btn {
     display: inline-flex;
     align-items: center;

--- a/static/js/calendar-export.js
+++ b/static/js/calendar-export.js
@@ -52,15 +52,39 @@ async function subscribeTripCalendar() {
     }
 }
 
-function _showSubscribeModal(url, copied) {
-    closeShareModal();
+// All-trips feed: single webcal:// URL covering every published trip with dates.
+// Shown from a button on the trips page header (not the share modal).
+async function subscribeAllTripsCalendar() {
+    try {
+        const res = await fetch('/api/calendar/subscribe-url');
+        if (!res.ok) {
+            alert('Could not generate calendar URL. Try again.');
+            return;
+        }
+        const data = await res.json();
+        const url = data.url || '';
+        if (!url) return;
+        try {
+            await navigator.clipboard.writeText(url);
+            _showSubscribeModal(url, true, 'Subscribe to all trips');
+        } catch {
+            _showSubscribeModal(url, false, 'Subscribe to all trips');
+        }
+    } catch (e) {
+        alert('Could not generate calendar URL: ' + e.message);
+    }
+}
+
+function _showSubscribeModal(url, copied, title) {
+    // closeShareModal is defined in upload.js; only call it when the share modal is open.
+    if (typeof closeShareModal === 'function') closeShareModal();
     const overlay = document.createElement('div');
     overlay.className = 'modal-overlay';
     overlay.innerHTML = `
         <div class="modal-dialog" style="max-width: 560px;">
             <div class="modal-header">
                 <i class="fas fa-rss" style="color: #f0c674; font-size: 1.6rem;"></i>
-                <h3>Subscribe to this trip</h3>
+                <h3>${title || 'Subscribe to this trip'}</h3>
             </div>
             <div class="modal-body">
                 <p style="margin-top:0">${copied ? '<i class="fas fa-check" style="color:#43a047"></i> Subscribe URL copied to clipboard.' : 'Copy this URL:'}</p>


### PR DESCRIPTION
Surfaces the new per-user calendar feed via a Subscribe button in the trips page header.

Clicking it calls `/api/calendar/subscribe-url`, copies the `webcal://` URL to clipboard, and shows the same subscribe modal used for per-trip calendar subscriptions (with instructions for Apple/Google/Outlook).

No new dependencies - reuses `_showSubscribeModal` from calendar-export.js.