### PR TITLE
Fix calendar subscribe button layout

### DIFF
--- a/agents/itinerary/templates/trips.html
+++ b/agents/itinerary/templates/trips.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/categories.css">
-    <link rel="stylesheet" href="/static/css/trips.css?v=15">
+    <link rel="stylesheet" href="/static/css/trips.css?v=16">
     <link rel="stylesheet" href="/static/css/trips-actions.css?v=3">
     <link rel="stylesheet" href="/static/css/trips-share-map.css?v=1">
 </head>
@@ -23,13 +23,13 @@
                 <h1><i class="fas fa-route"></i> My Trips</h1>
                 <p>Itineraries, ideas, and shared trips, all in one list.</p>
             </div>
-            <div class="trips-header-actions">
-                <button class="calendar-feed-btn" onclick="subscribeAllTripsCalendar()" title="Subscribe to all trips in your calendar app">
-                    <i class="fas fa-calendar-alt"></i> Subscribe
+            <a href="/create.html" class="new-trip-btn">
+                <i class="fas fa-plus"></i> New Trip
+            </a>
+            <div class="calendar-feed-link">
+                <button class="calendar-feed-btn" onclick="subscribeAllTripsCalendar()">
+                    <i class="fas fa-calendar-alt"></i> Subscribe to calendar
                 </button>
-                <a href="/create.html" class="new-trip-btn">
-                    <i class="fas fa-plus"></i> New Trip
-                </a>
             </div>
         </div>
     </div>

--- a/static/css/trips.css
+++ b/static/css/trips.css
@@ -26,32 +26,28 @@
     margin: 0 auto;
 }
 
-.trips-header-actions {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-top: 20px;
-    flex-wrap: wrap;
+.calendar-feed-link {
+    margin-top: 14px;
+    margin-bottom: 0;
 }
 
 .calendar-feed-btn {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
-    background: transparent;
-    color: #fff;
-    padding: 10px 20px;
-    border-radius: 25px;
-    font-size: 0.95rem;
-    font-weight: 600;
+    gap: 6px;
+    background: none;
+    border: none;
+    color: rgba(255,255,255,0.75);
+    font-size: 0.85rem;
     cursor: pointer;
-    border: 2px solid rgba(255,255,255,0.6);
-    transition: background 0.2s, border-color 0.2s;
+    padding: 0;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    transition: color 0.15s;
 }
 
 .calendar-feed-btn:hover {
-    background: rgba(255,255,255,0.15);
-    border-color: #fff;
+    color: #fff;
 }
 
 .new-trip-btn {


### PR DESCRIPTION
Subscribe was appearing as a ghost button alongside New Trip (left-aligned, competing). Now it sits below New Trip as a small dim underlined text link - clearly secondary.