### PR TITLE
Fix ICS DTSTAMP: emit Z suffix per RFC 5545

### DIFF
--- a/agents/trips/ics.py
+++ b/agents/trips/ics.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
+from datetime import UTC, datetime, timedelta
 from datetime import date as _date
-from datetime import datetime, timedelta, timezone
 
 from icalendar import Calendar, Event
 
@@ -83,7 +83,7 @@ def generate_ics_multi(trips: list[dict]) -> str:
     cal.add("METHOD", "PUBLISH")
     cal.add("X-WR-CALNAME", "Libertas Travel")
 
-    now_utc = datetime.now(timezone.utc)
+    now_utc = datetime.now(UTC)
 
     for trip in trips:
         link = trip.get("link", "unknown")
@@ -199,8 +199,8 @@ def generate_ics(export_data: dict, link: str) -> str:
     cal.add("X-WR-CALNAME", title)
 
     # RFC 5545 requires DTSTAMP to be a UTC datetime (Z suffix).
-    # Using now(timezone.utc) gives icalendar the tzinfo it needs to emit Z.
-    now_utc = datetime.now(timezone.utc)
+    # Using now(UTC) gives icalendar the tzinfo it needs to emit Z.
+    now_utc = datetime.now(UTC)
     event_count = 0
 
     for day in days:

--- a/agents/trips/ics.py
+++ b/agents/trips/ics.py
@@ -12,7 +12,7 @@ import hashlib
 import hmac
 import os
 from datetime import date as _date
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from icalendar import Calendar, Event
 
@@ -83,7 +83,7 @@ def generate_ics_multi(trips: list[dict]) -> str:
     cal.add("METHOD", "PUBLISH")
     cal.add("X-WR-CALNAME", "Libertas Travel")
 
-    now_utc = datetime.utcnow()
+    now_utc = datetime.now(timezone.utc)
 
     for trip in trips:
         link = trip.get("link", "unknown")
@@ -198,7 +198,9 @@ def generate_ics(export_data: dict, link: str) -> str:
     cal.add("METHOD", "PUBLISH")
     cal.add("X-WR-CALNAME", title)
 
-    now_utc = datetime.utcnow()
+    # RFC 5545 requires DTSTAMP to be a UTC datetime (Z suffix).
+    # Using now(timezone.utc) gives icalendar the tzinfo it needs to emit Z.
+    now_utc = datetime.now(timezone.utc)
     event_count = 0
 
     for day in days:


### PR DESCRIPTION
DTSTAMP was serialized as a floating time (no Z) because `datetime.utcnow()` is naive. Switched to `datetime.now(timezone.utc)` so icalendar emits the required Z suffix. DTSTART/DTEND remain floating — correct for travel where times are local to the destination.