### PR TITLE
Fix ICS timezone for Google Calendar

### DIFF
--- a/agents/pages/profile_view.py
+++ b/agents/pages/profile_view.py
@@ -35,6 +35,7 @@ def generate_profile_page(profile_data: dict[str, Any]) -> str:
     rules = _esc(style_profile.get("rules", ""))
     user_notes = _esc(profile_data.get("user_notes", ""))
     has_profile = "true" if style_profile else "false"
+    current_timezone = _esc(profile_data.get("timezone", ""))
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -219,6 +220,42 @@ def generate_profile_page(profile_data: dict[str, Any]) -> str:
             </div>
         </div>
 
+        <!-- Calendar Timezone -->
+        <div class="profile-section">
+            <h2><i class="fas fa-calendar-alt"></i> Calendar Timezone</h2>
+            <p style="color:#666;font-size:0.9rem;margin-bottom:16px">
+                Used for calendar subscriptions. Set this to your home timezone so events
+                show at the right time in Google Calendar.
+            </p>
+            <div class="field-group">
+                <select id="timezone-select">
+                    <option value="">Floating (default, works in Apple/Outlook)</option>
+                    <option value="America/Los_Angeles">America/Los_Angeles (Pacific)</option>
+                    <option value="America/Denver">America/Denver (Mountain)</option>
+                    <option value="America/Chicago">America/Chicago (Central)</option>
+                    <option value="America/New_York">America/New_York (Eastern)</option>
+                    <option value="America/Anchorage">America/Anchorage (Alaska)</option>
+                    <option value="Pacific/Honolulu">Pacific/Honolulu (Hawaii)</option>
+                    <option value="Europe/London">Europe/London</option>
+                    <option value="Europe/Paris">Europe/Paris (Central European)</option>
+                    <option value="Europe/Helsinki">Europe/Helsinki (Eastern European)</option>
+                    <option value="Asia/Dubai">Asia/Dubai (Gulf)</option>
+                    <option value="Asia/Kolkata">Asia/Kolkata (India)</option>
+                    <option value="Asia/Bangkok">Asia/Bangkok (Indochina)</option>
+                    <option value="Asia/Singapore">Asia/Singapore</option>
+                    <option value="Asia/Tokyo">Asia/Tokyo (Japan)</option>
+                    <option value="Australia/Sydney">Australia/Sydney (AEDT)</option>
+                </select>
+                <div class="field-hint">Your home timezone. Applies to all calendar exports.</div>
+            </div>
+            <div style="margin-top:12px">
+                <button class="btn-primary" id="save-tz-btn">
+                    <i class="fas fa-save"></i> Save Timezone
+                </button>
+                <span class="status-msg" id="tz-status"></span>
+            </div>
+        </div>
+
         <!-- User Notes -->
         <div class="profile-section">
             <h2><i class="fas fa-sticky-note"></i> Notes for AI</h2>
@@ -318,6 +355,40 @@ def generate_profile_page(profile_data: dict[str, Any]) -> str:
             }}
             btn.disabled = false;
         }});
+
+        // Timezone selector - pre-select saved value then save on click
+        (function() {{
+            const sel = document.getElementById('timezone-select');
+            const saved = {repr(current_timezone) if current_timezone else '""'};
+            if (saved) {{
+                for (const opt of sel.options) {{
+                    if (opt.value === saved) {{ opt.selected = true; break; }}
+                }}
+            }}
+            document.getElementById('save-tz-btn').addEventListener('click', async () => {{
+                const tz = sel.value;
+                const statusEl = document.getElementById('tz-status');
+                try {{
+                    const res = await fetch('/api/user/timezone', {{
+                        method: 'POST',
+                        headers: {{'Content-Type': 'application/json'}},
+                        body: JSON.stringify({{timezone: tz}}),
+                    }});
+                    const data = await res.json();
+                    if (data.ok) {{
+                        statusEl.textContent = 'Saved!';
+                        statusEl.className = 'status-msg success';
+                    }} else {{
+                        statusEl.textContent = data.error || 'Save failed';
+                        statusEl.className = 'status-msg error';
+                    }}
+                }} catch {{
+                    statusEl.textContent = 'Save failed';
+                    statusEl.className = 'status-msg error';
+                }}
+                setTimeout(() => {{ statusEl.textContent = ''; }}, 3000);
+            }});
+        }})();
     </script>
 </body>
 </html>"""

--- a/agents/trips/ics.py
+++ b/agents/trips/ics.py
@@ -14,7 +14,7 @@ import os
 from datetime import UTC, datetime, timedelta
 from datetime import date as _date
 
-from icalendar import Calendar, Event
+from icalendar import Calendar, Event, vDatetime, vText
 
 
 def calendar_subscribe_token(user_id: int, link: str) -> str:
@@ -68,13 +68,18 @@ def verify_user_calendar_token(user_id: int, provided: str) -> bool:
     return hmac.compare_digest(expected, provided)
 
 
-def generate_ics_multi(trips: list[dict]) -> str:
+def generate_ics_multi(trips: list[dict], tzid: str | None = None) -> str:
     """Generate a single ICS feed containing all events from multiple trips.
 
     Each trip dict must have ``title``, ``link``, and ``itinerary_data``
     (already parsed from JSON). Only days with a ``date`` are included;
     items without a date on their day are skipped (same rule as
     generate_ics).
+
+    tzid: IANA timezone name (e.g. "America/Los_Angeles"). When provided,
+    DTSTART/DTEND are tagged with TZID so Google Calendar displays the
+    correct local time. When None, times are emitted as floating (correct
+    per RFC 5545 but Google Calendar incorrectly interprets as UTC).
     """
     cal = Calendar()
     cal.add("VERSION", "2.0")
@@ -82,6 +87,8 @@ def generate_ics_multi(trips: list[dict]) -> str:
     cal.add("CALSCALE", "GREGORIAN")
     cal.add("METHOD", "PUBLISH")
     cal.add("X-WR-CALNAME", "Libertas Travel")
+    if tzid:
+        _add_tzid_calendar(cal, tzid)
 
     now_utc = datetime.now(UTC)
 
@@ -145,8 +152,8 @@ def generate_ics_multi(trips: list[dict]) -> str:
                             if end_hm
                             else start + timedelta(hours=1)
                         )
-                        event.add("DTSTART", start)
-                        event.add("DTEND", end)
+                        event.add("DTSTART", _dtstart(start, tzid))
+                        event.add("DTEND", _dtstart(end, tzid))
                 else:
                     event.add("DTSTART", day_date)
                     event.add("DTEND", day_date)
@@ -167,6 +174,20 @@ def generate_ics_multi(trips: list[dict]) -> str:
                 cal.add_component(event)
 
     return cal.to_ical().decode("utf-8")
+
+
+def _add_tzid_calendar(cal: Calendar, tzid: str) -> None:
+    """Add X-WR-TIMEZONE and a minimal VTIMEZONE stub so apps know the intent."""
+    cal.add("X-WR-TIMEZONE", vText(tzid))
+
+
+def _dtstart(dt: datetime, tzid: str | None):
+    """Return a vDatetime tagged with TZID, or a floating datetime if tzid is None."""
+    if tzid:
+        v = vDatetime(dt)
+        v.params["TZID"] = tzid
+        return v
+    return dt
 
 
 def _parse_hhmm(value: str) -> tuple[int, int] | None:

--- a/agents/trips/routes.py
+++ b/agents/trips/routes.py
@@ -182,7 +182,9 @@ def user_calendar_feed():
         return json_err("Invalid token", status=403)
 
     trips = db.get_published_trips_with_dates(user_id)
-    ics_content = generate_ics_multi(trips)
+    profile = db.get_user_profile(user_id) or {}
+    tzid = profile.get("timezone") or None
+    ics_content = generate_ics_multi(trips, tzid=tzid)
     return Response(
         ics_content,
         mimetype="text/calendar; charset=utf-8",
@@ -581,3 +583,22 @@ def save_user_profile():
     db.set_user_profile(g.user_id, existing_profile)
 
     return json_ok({"success": True})
+
+
+@trips_bp.post("/api/user/timezone")
+@require_auth
+def save_user_timezone():
+    """Save the user's home timezone for calendar export."""
+    data = request.get_json(silent=True) or {}
+    tzid = (data.get("timezone") or "").strip()
+    # Basic sanity check: must look like a valid IANA zone (e.g. America/Los_Angeles).
+    # We don't do a full lookup; invalid values just mean floating times in the ICS.
+    if tzid and ("/" not in tzid or len(tzid) > 64):
+        return json_err("Invalid timezone")
+    existing_profile = db.get_user_profile(g.user_id) or {}
+    if tzid:
+        existing_profile["timezone"] = tzid
+    else:
+        existing_profile.pop("timezone", None)
+    db.set_user_profile(g.user_id, existing_profile)
+    return json_ok({"success": True, "timezone": tzid or None})


### PR DESCRIPTION
Google Calendar treats floating ICS times as UTC, showing e.g. a 9:50 AM Pacific flight at 2:50 AM. Fix: let users set their home timezone in Profile, then tag DTSTART with TZID in the calendar feed. Apple Calendar and Outlook continue to work (they handle TZID correctly).