### PR TITLE
ICS: hotels and car rentals emit all-day span + timed check-in event

### DIFF
--- a/agents/trips/ics.py
+++ b/agents/trips/ics.py
@@ -16,6 +16,20 @@ from datetime import date as _date
 
 from icalendar import Calendar, Event, vDatetime, vText
 
+# Categories that represent a stay or rental spanning multiple days.
+# Items in these categories with an end_date get:
+#   1. An all-day multi-day span event (the "bar" across the calendar)
+#   2. A separate timed check-in/pickup event on the start day
+# Everything else gets a single timed event (or all-day if no time).
+_SPAN_CATEGORIES = frozenset(["hotel", "lodging", "transport"])
+
+# Labels for the timed companion event by category.
+_CHECKIN_LABEL = {
+    "hotel": "Check-in: ",
+    "lodging": "Check-in: ",
+    "transport": "Pickup: ",
+}
+
 
 def calendar_subscribe_token(user_id: int, link: str) -> str:
     """Build a deterministic per-(user, trip) HMAC token.
@@ -91,12 +105,12 @@ def generate_ics_multi(trips: list[dict], tzid: str | None = None) -> str:
         _add_tzid_calendar(cal, tzid)
 
     now_utc = datetime.now(UTC)
+    event_count = 0
 
     for trip in trips:
         link = trip.get("link", "unknown")
         itinerary_data = trip.get("itinerary_data") or {}
         days = itinerary_data.get("days", [])
-        event_count = 0
 
         for day in days:
             day_date_str = day.get("date")
@@ -109,94 +123,11 @@ def generate_ics_multi(trips: list[dict], tzid: str | None = None) -> str:
 
             for item in day.get("items", []):
                 event_count += 1
-                item_title = item.get("title", "Activity")
-                item_time = item.get("time")
-                item_end_time = item.get("end_time")
-                item_location = item.get("location", "")
-                item_notes = item.get("notes", "")
-                item_category = item.get("category", "activity")
-                item_website = item.get("website", "")
-
-                event = Event()
-                event.add("UID", f"{link}-{day_date_str}-{event_count}@libertas.app")
-                event.add("DTSTAMP", now_utc)
-                event.add("SUMMARY", item_title)
-
-                if item_time:
-                    start_hm = _parse_hhmm(item_time)
-                    if start_hm is None:
-                        event.add("DTSTART", day_date)
-                        event.add("DTEND", day_date)
-                    else:
-                        start = datetime.combine(
-                            day_date,
-                            datetime.min.time().replace(hour=start_hm[0], minute=start_hm[1]),
-                        )
-                        end_hm = _parse_hhmm(item_end_time) if item_end_time else None
-
-                        end_date_str = item.get("end_date")
-                        end_date = day_date
-                        if end_date_str:
-                            try:
-                                end_date = _date.fromisoformat(end_date_str)
-                            except ValueError:
-                                pass
-                        elif end_hm and (end_hm[0], end_hm[1]) < (start_hm[0], start_hm[1]):
-                            end_date = day_date + timedelta(days=1)
-
-                        end = (
-                            datetime.combine(
-                                end_date,
-                                datetime.min.time().replace(hour=end_hm[0], minute=end_hm[1]),
-                            )
-                            if end_hm
-                            else start + timedelta(hours=1)
-                        )
-                        event.add("DTSTART", _dtstart(start, tzid))
-                        event.add("DTEND", _dtstart(end, tzid))
-                else:
-                    event.add("DTSTART", day_date)
-                    event.add("DTEND", day_date)
-
-                if item_location:
-                    event.add("LOCATION", item_location)
-
-                desc_parts = []
-                if item_category:
-                    desc_parts.append(f"Category: {item_category.title()}")
-                if item_notes:
-                    desc_parts.append(item_notes)
-                if item_website:
-                    desc_parts.append(f"Website: {item_website}")
-                if desc_parts:
-                    event.add("DESCRIPTION", "\n".join(desc_parts))
-
-                cal.add_component(event)
+                uid_prefix = f"{link}-{day_date_str}-{event_count}"
+                for event in _build_events(item, day_date, uid_prefix, now_utc, tzid):
+                    cal.add_component(event)
 
     return cal.to_ical().decode("utf-8")
-
-
-def _add_tzid_calendar(cal: Calendar, tzid: str) -> None:
-    """Add X-WR-TIMEZONE and a minimal VTIMEZONE stub so apps know the intent."""
-    cal.add("X-WR-TIMEZONE", vText(tzid))
-
-
-def _dtstart(dt: datetime, tzid: str | None):
-    """Return a vDatetime tagged with TZID, or a floating datetime if tzid is None."""
-    if tzid:
-        v = vDatetime(dt)
-        v.params["TZID"] = tzid
-        return v
-    return dt
-
-
-def _parse_hhmm(value: str) -> tuple[int, int] | None:
-    """Parse 'HH:MM' into (hour, minute), or None if malformed."""
-    try:
-        h, m = value.split(":", 1)
-        return int(h), int(m)
-    except (ValueError, AttributeError):
-        return None
 
 
 def generate_ics(export_data: dict, link: str) -> str:
@@ -236,76 +167,230 @@ def generate_ics(export_data: dict, link: str) -> str:
 
         for item in day.get("items", []):
             event_count += 1
-            item_title = item.get("title", "Activity")
-            item_time = item.get("time")
-            item_end_time = item.get("end_time")
-            item_location = item.get("location", "")
-            item_notes = item.get("notes", "")
-            item_category = item.get("category", "activity")
-            item_website = item.get("website", "")
+            uid_prefix = f"{link}-{day_date_str}-{event_count}"
+            for event in _build_events(item, day_date, uid_prefix, now_utc, tzid=None):
+                cal.add_component(event)
 
-            event = Event()
-            event.add("UID", f"{link}-{day_date_str}-{event_count}@libertas.app")
-            event.add("DTSTAMP", now_utc)
-            event.add("SUMMARY", item_title)
-
-            if item_time:
-                start_hm = _parse_hhmm(item_time)
-                if start_hm is None:
-                    # Fall back to all-day if the time string is malformed
-                    event.add("DTSTART", day_date)
-                    event.add("DTEND", day_date)
-                else:
-                    start = datetime.combine(
-                        day_date, datetime.min.time().replace(hour=start_hm[0], minute=start_hm[1])
-                    )
-                    end_hm = _parse_hhmm(item_end_time) if item_end_time else None
-
-                    # End-date resolution priority:
-                    #   1. explicit item["end_date"] (hotels, car rentals)
-                    #   2. inferred next-day if end_time < start_time
-                    #      (red-eye flights, late-night dinners that go past midnight)
-                    #   3. same day as start
-                    end_date_str = item.get("end_date")
-                    end_date = day_date
-                    if end_date_str:
-                        try:
-                            end_date = _date.fromisoformat(end_date_str)
-                        except ValueError:
-                            pass
-                    elif end_hm and (end_hm[0], end_hm[1]) < (start_hm[0], start_hm[1]):
-                        end_date = day_date + timedelta(days=1)
-
-                    end = (
-                        datetime.combine(
-                            end_date,
-                            datetime.min.time().replace(hour=end_hm[0], minute=end_hm[1]),
-                        )
-                        if end_hm
-                        else start + timedelta(hours=1)
-                    )
-                    event.add("DTSTART", start)
-                    event.add("DTEND", end)
-            else:
-                # All-day event
-                event.add("DTSTART", day_date)
-                event.add("DTEND", day_date)
-
-            if item_location:
-                event.add("LOCATION", item_location)
-
-            desc_parts = []
-            if item_category:
-                desc_parts.append(f"Category: {item_category.title()}")
-            if item_notes:
-                desc_parts.append(item_notes)
-            if item_website:
-                desc_parts.append(f"Website: {item_website}")
-            if desc_parts:
-                # icalendar handles the literal-newline escaping for us.
-                event.add("DESCRIPTION", "\n".join(desc_parts))
-
-            cal.add_component(event)
-
-    # to_ical() returns bytes; the route layer wants str.
     return cal.to_ical().decode("utf-8")
+
+
+def _build_events(
+    item: dict,
+    day_date: _date,
+    uid_prefix: str,
+    now_utc: datetime,
+    tzid: str | None,
+) -> list[Event]:
+    """Build one or two VEVENT objects for a single itinerary item.
+
+    Hotels and car rentals with an end_date produce two events:
+      - An all-day span across the full stay/rental period (the "bar")
+      - A timed check-in/pickup event on the start day
+
+    Everything else (flights, meals, activities) produces one timed event,
+    or an all-day event when no time is given.
+    """
+    category = (item.get("category") or "activity").lower()
+    title = item.get("title", "Activity")
+    item_time = item.get("time")
+    item_end_time = item.get("end_time")
+    end_date_str = item.get("end_date")
+    location = item.get("location", "")
+    notes = item.get("notes", "")
+    website = item.get("website", "")
+
+    desc_parts = []
+    if category:
+        desc_parts.append(f"Category: {category.title()}")
+    if notes:
+        desc_parts.append(notes)
+    if website:
+        desc_parts.append(f"Website: {website}")
+    description = "\n".join(desc_parts) if desc_parts else None
+
+    # Hotels and rentals with a known end date get an all-day span + timed
+    # companion event, matching how TripIt renders them.
+    if category in _SPAN_CATEGORIES and end_date_str:
+        return _build_span_events(
+            title,
+            category,
+            day_date,
+            end_date_str,
+            item_time,
+            item_end_time,
+            location,
+            description,
+            uid_prefix,
+            now_utc,
+            tzid,
+        )
+
+    # All other categories: single timed (or all-day) event.
+    return [
+        _build_timed_event(
+            title,
+            day_date,
+            item_time,
+            item_end_time,
+            end_date_str,
+            location,
+            description,
+            uid_prefix,
+            now_utc,
+            tzid,
+        )
+    ]
+
+
+def _build_span_events(
+    title: str,
+    category: str,
+    day_date: _date,
+    end_date_str: str,
+    item_time: str | None,
+    item_end_time: str | None,
+    location: str,
+    description: str | None,
+    uid_prefix: str,
+    now_utc: datetime,
+    tzid: str | None,
+) -> list[Event]:
+    """Two events for a multi-day stay or rental."""
+    try:
+        end_date = _date.fromisoformat(end_date_str)
+    except ValueError:
+        end_date = day_date
+
+    events: list[Event] = []
+
+    # All-day span event (the colored bar across the calendar week view).
+    # DTEND is exclusive for all-day events per RFC 5545.
+    span = Event()
+    span.add("UID", f"{uid_prefix}-span@libertas.app")
+    span.add("DTSTAMP", now_utc)
+    span.add("SUMMARY", title)
+    span.add("DTSTART", day_date)
+    span.add("DTEND", end_date + timedelta(days=1))
+    if location:
+        span.add("LOCATION", location)
+    if description:
+        span.add("DESCRIPTION", description)
+    events.append(span)
+
+    # Timed companion event on the start day for the check-in/pickup time.
+    if item_time:
+        start_hm = _parse_hhmm(item_time)
+        if start_hm:
+            start = datetime.combine(
+                day_date,
+                datetime.min.time().replace(hour=start_hm[0], minute=start_hm[1]),
+            )
+            end_hm = _parse_hhmm(item_end_time) if item_end_time else None
+            end = (
+                datetime.combine(
+                    day_date,
+                    datetime.min.time().replace(hour=end_hm[0], minute=end_hm[1]),
+                )
+                if end_hm
+                else start + timedelta(hours=1)
+            )
+            label = _CHECKIN_LABEL.get(category, "")
+            checkin = Event()
+            checkin.add("UID", f"{uid_prefix}-checkin@libertas.app")
+            checkin.add("DTSTAMP", now_utc)
+            checkin.add("SUMMARY", label + title)
+            checkin.add("DTSTART", _dtstart(start, tzid))
+            checkin.add("DTEND", _dtstart(end, tzid))
+            if location:
+                checkin.add("LOCATION", location)
+            events.append(checkin)
+
+    return events
+
+
+def _build_timed_event(
+    title: str,
+    day_date: _date,
+    item_time: str | None,
+    item_end_time: str | None,
+    end_date_str: str | None,
+    location: str,
+    description: str | None,
+    uid_prefix: str,
+    now_utc: datetime,
+    tzid: str | None,
+) -> Event:
+    """Single timed (or all-day) event for flights, meals, activities, etc."""
+    event = Event()
+    event.add("UID", f"{uid_prefix}@libertas.app")
+    event.add("DTSTAMP", now_utc)
+    event.add("SUMMARY", title)
+
+    if item_time:
+        start_hm = _parse_hhmm(item_time)
+        if start_hm is None:
+            event.add("DTSTART", day_date)
+            event.add("DTEND", day_date)
+        else:
+            start = datetime.combine(
+                day_date,
+                datetime.min.time().replace(hour=start_hm[0], minute=start_hm[1]),
+            )
+            end_hm = _parse_hhmm(item_end_time) if item_end_time else None
+
+            # End-date resolution priority:
+            #   1. explicit item["end_date"] (cross-day flights)
+            #   2. inferred next-day if end_time < start_time (red-eye, midnight crossings)
+            #   3. same day as start
+            end_date = day_date
+            if end_date_str:
+                try:
+                    end_date = _date.fromisoformat(end_date_str)
+                except ValueError:
+                    pass
+            elif end_hm and (end_hm[0], end_hm[1]) < (start_hm[0], start_hm[1]):
+                end_date = day_date + timedelta(days=1)
+
+            end = (
+                datetime.combine(
+                    end_date,
+                    datetime.min.time().replace(hour=end_hm[0], minute=end_hm[1]),
+                )
+                if end_hm
+                else start + timedelta(hours=1)
+            )
+            event.add("DTSTART", _dtstart(start, tzid))
+            event.add("DTEND", _dtstart(end, tzid))
+    else:
+        event.add("DTSTART", day_date)
+        event.add("DTEND", day_date)
+
+    if location:
+        event.add("LOCATION", location)
+    if description:
+        event.add("DESCRIPTION", description)
+
+    return event
+
+
+def _add_tzid_calendar(cal: Calendar, tzid: str) -> None:
+    """Add X-WR-TIMEZONE hint so apps know the intended timezone."""
+    cal.add("X-WR-TIMEZONE", vText(tzid))
+
+
+def _dtstart(dt: datetime, tzid: str | None):
+    """Return a vDatetime tagged with TZID, or a floating datetime if tzid is None."""
+    if tzid:
+        v = vDatetime(dt)
+        v.params["TZID"] = tzid
+        return v
+    return dt
+
+
+def _parse_hhmm(value: str) -> tuple[int, int] | None:
+    """Parse 'HH:MM' into (hour, minute), or None if malformed."""
+    try:
+        h, m = value.split(":", 1)
+        return int(h), int(m)
+    except (ValueError, AttributeError):
+        return None

--- a/tests/test_calendar_export.py
+++ b/tests/test_calendar_export.py
@@ -292,9 +292,8 @@ class TestGeneratedIcsFormat:
         # Arrival on Jun 22 06:34, NOT Jun 21
         assert "20260622T063400" in ics
 
-    def test_explicit_end_date_is_honored(self):
-        """Multi-day items (hotels, car rentals) carry their own end_date.
-        The exporter should use it directly."""
+    def test_hotel_emits_span_and_checkin(self):
+        """Hotels with end_date produce two events: an all-day span and a timed check-in."""
         ics = generate_ics(
             self._export_payload(
                 [
@@ -305,7 +304,6 @@ class TestGeneratedIcsFormat:
                                 "title": "Marriott Seattle",
                                 "category": "hotel",
                                 "time": "16:00",
-                                "end_time": "11:00",
                                 "end_date": "2026-06-15",
                             }
                         ],
@@ -314,9 +312,60 @@ class TestGeneratedIcsFormat:
             ),
             "trip.html",
         )
-        # Check-in 2026-06-10 16:00, check-out 2026-06-15 11:00
+        # All-day span: DTSTART;VALUE=DATE:20260610, DTEND;VALUE=DATE:20260616 (exclusive)
+        assert "20260610" in ics
+        assert "20260616" in ics
+        # Timed check-in event on start day
         assert "20260610T160000" in ics
-        assert "20260615T110000" in ics
+        # Summary includes "Check-in:" prefix
+        assert "Check-in: Marriott Seattle" in ics
+
+    def test_transport_emits_span_and_pickup(self):
+        """Car rentals (transport) with end_date produce a span and a timed pickup event."""
+        ics = generate_ics(
+            self._export_payload(
+                [
+                    {
+                        "date": "2026-06-10",
+                        "items": [
+                            {
+                                "title": "Hertz Midsize",
+                                "category": "transport",
+                                "time": "08:00",
+                                "end_date": "2026-06-20",
+                            }
+                        ],
+                    }
+                ]
+            ),
+            "trip.html",
+        )
+        assert "20260610" in ics
+        assert "20260621" in ics  # exclusive end = end_date + 1
+        assert "20260610T080000" in ics
+        assert "Pickup: Hertz Midsize" in ics
+
+    def test_hotel_without_end_date_is_timed_event(self):
+        """A hotel item without end_date falls through to a single timed event."""
+        ics = generate_ics(
+            self._export_payload(
+                [
+                    {
+                        "date": "2026-06-10",
+                        "items": [
+                            {
+                                "title": "Marriott Seattle",
+                                "category": "hotel",
+                                "time": "16:00",
+                            }
+                        ],
+                    }
+                ]
+            ),
+            "trip.html",
+        )
+        assert "20260610T160000" in ics
+        assert "Check-in:" not in ics
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Matches TripIt calendar style.

- Hotels and car rentals with `end_date` now emit two events: an all-day multi-day span (the colored bar) + a separate timed Check-in/Pickup event on the start day
- Flights, meals, and activities continue as single timed events
- Refactored `generate_ics` and `generate_ics_multi` to share `_build_events()` helper
- 38 tests passing