### PR TITLE
Revert per-user timezone from ICS - back to floating times

### DIFF
--- a/agents/pages/profile_view.py
+++ b/agents/pages/profile_view.py
@@ -35,7 +35,6 @@ def generate_profile_page(profile_data: dict[str, Any]) -> str:
     rules = _esc(style_profile.get("rules", ""))
     user_notes = _esc(profile_data.get("user_notes", ""))
     has_profile = "true" if style_profile else "false"
-    current_timezone = _esc(profile_data.get("timezone", ""))
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -220,42 +219,6 @@ def generate_profile_page(profile_data: dict[str, Any]) -> str:
             </div>
         </div>
 
-        <!-- Calendar Timezone -->
-        <div class="profile-section">
-            <h2><i class="fas fa-calendar-alt"></i> Calendar Timezone</h2>
-            <p style="color:#666;font-size:0.9rem;margin-bottom:16px">
-                Used for calendar subscriptions. Set this to your home timezone so events
-                show at the right time in Google Calendar.
-            </p>
-            <div class="field-group">
-                <select id="timezone-select">
-                    <option value="">Floating (default, works in Apple/Outlook)</option>
-                    <option value="America/Los_Angeles">America/Los_Angeles (Pacific)</option>
-                    <option value="America/Denver">America/Denver (Mountain)</option>
-                    <option value="America/Chicago">America/Chicago (Central)</option>
-                    <option value="America/New_York">America/New_York (Eastern)</option>
-                    <option value="America/Anchorage">America/Anchorage (Alaska)</option>
-                    <option value="Pacific/Honolulu">Pacific/Honolulu (Hawaii)</option>
-                    <option value="Europe/London">Europe/London</option>
-                    <option value="Europe/Paris">Europe/Paris (Central European)</option>
-                    <option value="Europe/Helsinki">Europe/Helsinki (Eastern European)</option>
-                    <option value="Asia/Dubai">Asia/Dubai (Gulf)</option>
-                    <option value="Asia/Kolkata">Asia/Kolkata (India)</option>
-                    <option value="Asia/Bangkok">Asia/Bangkok (Indochina)</option>
-                    <option value="Asia/Singapore">Asia/Singapore</option>
-                    <option value="Asia/Tokyo">Asia/Tokyo (Japan)</option>
-                    <option value="Australia/Sydney">Australia/Sydney (AEDT)</option>
-                </select>
-                <div class="field-hint">Your home timezone. Applies to all calendar exports.</div>
-            </div>
-            <div style="margin-top:12px">
-                <button class="btn-primary" id="save-tz-btn">
-                    <i class="fas fa-save"></i> Save Timezone
-                </button>
-                <span class="status-msg" id="tz-status"></span>
-            </div>
-        </div>
-
         <!-- User Notes -->
         <div class="profile-section">
             <h2><i class="fas fa-sticky-note"></i> Notes for AI</h2>
@@ -356,39 +319,6 @@ def generate_profile_page(profile_data: dict[str, Any]) -> str:
             btn.disabled = false;
         }});
 
-        // Timezone selector - pre-select saved value then save on click
-        (function() {{
-            const sel = document.getElementById('timezone-select');
-            const saved = {repr(current_timezone) if current_timezone else '""'};
-            if (saved) {{
-                for (const opt of sel.options) {{
-                    if (opt.value === saved) {{ opt.selected = true; break; }}
-                }}
-            }}
-            document.getElementById('save-tz-btn').addEventListener('click', async () => {{
-                const tz = sel.value;
-                const statusEl = document.getElementById('tz-status');
-                try {{
-                    const res = await fetch('/api/user/timezone', {{
-                        method: 'POST',
-                        headers: {{'Content-Type': 'application/json'}},
-                        body: JSON.stringify({{timezone: tz}}),
-                    }});
-                    const data = await res.json();
-                    if (data.success) {{
-                        statusEl.textContent = 'Saved!';
-                        statusEl.className = 'status-msg success';
-                    }} else {{
-                        statusEl.textContent = data.error || 'Save failed';
-                        statusEl.className = 'status-msg error';
-                    }}
-                }} catch {{
-                    statusEl.textContent = 'Save failed';
-                    statusEl.className = 'status-msg error';
-                }}
-                setTimeout(() => {{ statusEl.textContent = ''; }}, 3000);
-            }});
-        }})();
     </script>
 </body>
 </html>"""

--- a/agents/trips/routes.py
+++ b/agents/trips/routes.py
@@ -182,9 +182,7 @@ def user_calendar_feed():
         return json_err("Invalid token", status=403)
 
     trips = db.get_published_trips_with_dates(user_id)
-    profile = db.get_user_profile(user_id) or {}
-    tzid = profile.get("timezone") or None
-    ics_content = generate_ics_multi(trips, tzid=tzid)
+    ics_content = generate_ics_multi(trips)
     return Response(
         ics_content,
         mimetype="text/calendar; charset=utf-8",
@@ -583,22 +581,3 @@ def save_user_profile():
     db.set_user_profile(g.user_id, existing_profile)
 
     return json_ok({"success": True})
-
-
-@trips_bp.post("/api/user/timezone")
-@require_auth
-def save_user_timezone():
-    """Save the user's home timezone for calendar export."""
-    data = request.get_json(silent=True) or {}
-    tzid = (data.get("timezone") or "").strip()
-    # Basic sanity check: must look like a valid IANA zone (e.g. America/Los_Angeles).
-    # We don't do a full lookup; invalid values just mean floating times in the ICS.
-    if tzid and ("/" not in tzid or len(tzid) > 64):
-        return json_err("Invalid timezone")
-    existing_profile = db.get_user_profile(g.user_id) or {}
-    if tzid:
-        existing_profile["timezone"] = tzid
-    else:
-        existing_profile.pop("timezone", None)
-    db.set_user_profile(g.user_id, existing_profile)
-    return json_ok({"success": True, "timezone": tzid or None})


### PR DESCRIPTION
The per-user timezone is wrong for travel: a 9pm dinner in NY should show as 9pm regardless of the user's home timezone.

- Remove `/api/user/timezone` route
- Remove Calendar Timezone section from profile page
- Feed no longer reads timezone from profile
- All timed events use floating times (RFC 5545 correct for wall-clock local time)

Apple Calendar and Outlook handle floating times correctly. Google Calendar incorrectly treats them as UTC - fixing that requires per-trip timezone, which is a separate feature.