### PR TITLE
Remove 120-char truncation from explore venue descriptions

### DIFF
--- a/agents/explore/static/js/explore.js
+++ b/agents/explore/static/js/explore.js
@@ -443,11 +443,7 @@ function createVenueCard(venue) {
 
     const location = buildVenueLocation(venue);
 
-    // Description (truncated to ~100 chars)
-    let description = venue.description || venue.notes || '';
-    if (description.length > 120) {
-        description = description.substring(0, 117) + '...';
-    }
+    const description = venue.description || venue.notes || '';
     const descriptionHtml = description
         ? `<div class="venue-card-description">${description}</div>`
         : '';


### PR DESCRIPTION
Venue descriptions (hiking trails, etc.) were being cut off mid-sentence at 120 characters. Removed the hard truncation so full descriptions display on venue cards.