### PR TITLE
Persist writeup to DB on generate; preserve it across autosaves

### DIFF
--- a/agents/create/handler.py
+++ b/agents/create/handler.py
@@ -127,18 +127,25 @@ def save_trip_handler(user_id: int, link: str, data: dict[str, Any]) -> dict[str
         return {"error": "No itinerary data provided"}, 400
 
     needs_map_regen = False
-    if "map_data" not in itinerary_data:
+    needs_existing = "map_data" not in itinerary_data or "writeup" not in itinerary_data
+    existing_data: dict = {}
+    if needs_existing:
         existing_trip = db.get_trip_by_link(user_id, link)
         if existing_trip:
             existing_data = existing_trip.get("itinerary_data") or {}
-            if existing_data.get("map_data"):
-                old_flags = _extract_home_location_flags(existing_data)
-                new_flags = _extract_home_location_flags(itinerary_data)
-                if old_flags == new_flags:
-                    itinerary_data["map_data"] = existing_data["map_data"]
-                else:
-                    print(f"[SAVE] is_home_location changed for {link}, will regen map")
-                    needs_map_regen = True
+
+    if "map_data" not in itinerary_data and existing_data.get("map_data"):
+        old_flags = _extract_home_location_flags(existing_data)
+        new_flags = _extract_home_location_flags(itinerary_data)
+        if old_flags == new_flags:
+            itinerary_data["map_data"] = existing_data["map_data"]
+        else:
+            print(f"[SAVE] is_home_location changed for {link}, will regen map")
+            needs_map_regen = True
+
+    # Preserve a saved writeup unless the caller is explicitly sending a new one.
+    if "writeup" not in itinerary_data and existing_data.get("writeup"):
+        itinerary_data["writeup"] = existing_data["writeup"]
 
     title = data.get("title")
     print(f"[SAVE] link={link}, title={title}")

--- a/agents/pages/routes.py
+++ b/agents/pages/routes.py
@@ -345,6 +345,12 @@ def writeup_view(rec_name: str):
                 style_profile=style_profile,
                 writing_samples=writing_samples,
             )
+            # Cache so future visits don't regenerate.
+            itinerary_data["writeup"] = writeup_text
+            try:
+                db.update_trip_itinerary_data(owner_id, link, itinerary_data)
+            except Exception as save_err:
+                print(f"[writeup] failed to cache for {link}: {save_err}")
         except Exception as e:
             # Log the actual cause, silently swallowing made debugging painful
             import traceback

--- a/agents/trips/handler.py
+++ b/agents/trips/handler.py
@@ -87,6 +87,13 @@ def generate_writeup_for_trip(user_id: int, link: str) -> tuple[dict, int]:
     except Exception as e:
         return {"error": f"Write-up generation failed: {e}"}, 500
 
+    # Persist so the /w/ public page uses this version without regenerating.
+    itinerary_data["writeup"] = text
+    try:
+        db.update_trip_itinerary_data(user_id, link, itinerary_data)
+    except Exception as e:
+        print(f"[writeup] failed to persist for {link}: {e}")
+
     return {"writeup": text, "personalized": bool(style_profile)}, 200
 
 

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -173,6 +173,102 @@ class TestRecommendationRoutes:
 
 
 # ---------------------------------------------------------------------------
+# Writeup persistence
+# ---------------------------------------------------------------------------
+
+
+class TestWriteupPersistence:
+    def test_autosave_preserves_existing_writeup(self, client):
+        """A normal autosave (no writeup in payload) must not clear a saved writeup."""
+        import database as db
+
+        resp = client.post("/api/trips/create", json={"title": "Writeup Persist Test"})
+        link = resp.get_json().get("trip", {}).get("link", "")
+        assert link
+
+        try:
+            # Seed the DB with a writeup
+            trip = db.get_trip_by_link(1, link)
+            seed_data = trip.get("itinerary_data") or {}
+            seed_data["writeup"] = "Original write-up text"
+            db.update_trip_itinerary_data(1, link, seed_data)
+
+            # Autosave without writeup in payload
+            save_resp = client.post(
+                f"/api/trips/{link}/save",
+                json={
+                    "title": "Writeup Persist Test",
+                    "itinerary_data": {"days": [], "ideas": [], "tips": []},
+                },
+            )
+            assert save_resp.status_code == 200
+
+            # Writeup must still be there
+            updated = db.get_trip_by_link(1, link)
+            assert updated["itinerary_data"].get("writeup") == "Original write-up text"
+        finally:
+            if link:
+                db.delete_trip(1, link)
+
+    def test_autosave_with_writeup_in_payload_updates_it(self, client):
+        """If a save explicitly includes a writeup, it replaces the stored one."""
+        import database as db
+
+        resp = client.post("/api/trips/create", json={"title": "Writeup Replace Test"})
+        link = resp.get_json().get("trip", {}).get("link", "")
+        assert link
+
+        try:
+            save_resp = client.post(
+                f"/api/trips/{link}/save",
+                json={
+                    "title": "Writeup Replace Test",
+                    "itinerary_data": {
+                        "days": [],
+                        "ideas": [],
+                        "tips": [],
+                        "writeup": "Updated write-up",
+                    },
+                },
+            )
+            assert save_resp.status_code == 200
+
+            updated = db.get_trip_by_link(1, link)
+            assert updated["itinerary_data"].get("writeup") == "Updated write-up"
+        finally:
+            if link:
+                db.delete_trip(1, link)
+
+    def test_generate_writeup_endpoint_persists_to_db(self, client):
+        """POST /api/trips/<link>/writeup must save the writeup into itinerary_data."""
+        import unittest.mock as mock
+
+        import database as db
+
+        resp = client.post("/api/trips/create", json={"title": "Gen Writeup Test"})
+        link = resp.get_json().get("trip", {}).get("link", "")
+        assert link
+
+        try:
+            with mock.patch(
+                "agents.trips.writeup.generate_writeup",
+                return_value="Mocked write-up text",
+            ):
+                gen_resp = client.post(f"/api/trips/{link}/writeup")
+
+            assert gen_resp.status_code == 200
+            data = gen_resp.get_json()
+            assert data.get("writeup") == "Mocked write-up text"
+
+            # Must be persisted
+            saved = db.get_trip_by_link(1, link)
+            assert saved["itinerary_data"].get("writeup") == "Mocked write-up text"
+        finally:
+            if link:
+                db.delete_trip(1, link)
+
+
+# ---------------------------------------------------------------------------
 # Data model: ideas with links
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Three bugs causing write-up text to be lost or regenerated:

1. `generate_writeup_for_trip` generated text but never saved it to `itinerary_data["writeup"]` - the JS was supposed to do a follow-up save, but that only works from the trip editor and was fire-and-forget. Fixed: save server-side immediately after generating.

2. The `/w/<link>` on-the-fly generation path also never saved. Every visit by a new viewer would trigger a fresh LLM call and potentially return different text. Fixed: save after generating so future visits use the cached version.

3. Normal autosave from the trip editor sent `{days, ideas, tips, chatHistory}` without `writeup`, which replaced the stored `itinerary_data` and silently dropped the writeup. Fixed: `save_trip_handler` now preserves the existing writeup when the incoming payload doesn't include one (same pattern as the existing `map_data` preservation logic).