### PR TITLE
Auth plugin: wire fla-auth, add change/forgot/reset password

### DIFF
--- a/agents/auth/routes.py
+++ b/agents/auth/routes.py
@@ -1,65 +1,19 @@
-"""Auth blueprint: login, register, logout."""
+"""Auth blueprint - thin shim that delegates to fiat_lux_agents.auth.
+
+All logic lives in the fla-auth plugin. This file just configures it
+with the app's DB connection and invite-code env var.
+"""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import os
 
-from flask import Blueprint, request, session
+from fiat_lux_agents.auth import make_auth_blueprint
 
-from agents.auth import credentials as auth
-from agents.common.flask_utils import json_err, json_ok
+from database.connection import USE_POSTGRES, get_db
 
-auth_bp = Blueprint("auth", __name__)
-
-
-@auth_bp.post("/api/login")
-def login():
-    data = request.get_json(silent=True) or {}
-    username = data.get("username", "").strip()
-    password = data.get("password", "").strip()
-
-    if not username or not password:
-        return json_err("Username and password required")
-
-    user = auth.verify_credentials(username, password)
-    if not user:
-        return json_err("Invalid username or password", status=401)
-
-    session["user_id"] = user["id"]
-    session["username"] = user["username"]
-    return json_ok({"success": True, "username": user["username"]})
-
-
-@auth_bp.post("/api/register")
-def register():
-    import os
-
-    data = request.get_json(silent=True) or {}
-    username = data.get("username", "").strip()
-    email = data.get("email", "").strip()
-    password = data.get("password", "").strip()
-    invite_code = data.get("invite_code", "").strip()
-
-    # If INVITE_CODE env var is set, require a matching code to register.
-    expected = os.environ.get("INVITE_CODE", "")
-    if expected:
-        if not invite_code:
-            return json_err("An invite code is required to register.")
-        if invite_code != expected:
-            return json_err("Invalid invite code.")
-
-    success, error = auth.register_user(username, email, password)
-    if success:
-        # Greppable line in Render logs so the owner can monitor signups
-        # via `render logs | grep '\[SIGNUP\]'`. Email/IP intentionally
-        # omitted from logs, keep PII out of the log stream.
-        ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        print(f"[SIGNUP] {username} @ {ts}", flush=True)
-        return json_ok({"success": True})
-    return json_err(error)
-
-
-@auth_bp.post("/api/logout")
-def logout():
-    session.clear()
-    return json_ok({"success": True})
+auth_bp = make_auth_blueprint(
+    get_connection=get_db,
+    use_postgres=USE_POSTGRES,
+    invite_code=os.environ.get("INVITE_CODE", ""),
+)

--- a/agents/auth/routes.py
+++ b/agents/auth/routes.py
@@ -1,7 +1,7 @@
 """Auth blueprint - thin shim that delegates to fiat_lux_agents.auth.
 
 All logic lives in the fla-auth plugin. This file just configures it
-with the app's DB connection and invite-code env var.
+with the app's DB connection and env vars.
 """
 
 from __future__ import annotations
@@ -12,8 +12,15 @@ from fiat_lux_agents.auth import make_auth_blueprint
 
 from database.connection import USE_POSTGRES, get_db
 
+_APP_URL = os.environ.get("APP_URL", "https://libertas-travel.onrender.com")
+_FROM_EMAIL = os.environ.get("FROM_EMAIL", "noreply@libertas-travel.onrender.com")
+
 auth_bp = make_auth_blueprint(
     get_connection=get_db,
     use_postgres=USE_POSTGRES,
     invite_code=os.environ.get("INVITE_CODE", ""),
+    secret_key=os.environ.get("SECRET_KEY", ""),
+    app_url=_APP_URL,
+    from_email=_FROM_EMAIL,
+    app_name="Libertas",
 )

--- a/agents/common/templates.py
+++ b/agents/common/templates.py
@@ -141,3 +141,11 @@ def generate_login_page() -> str:
 def generate_register_page() -> str:
     """Generate the Register page HTML."""
     return get_template("register.html")
+
+
+def generate_forgot_password_page() -> str:
+    return get_template("forgot-password.html")
+
+
+def generate_reset_password_page() -> str:
+    return get_template("reset-password.html")

--- a/agents/common/templates/forgot-password.html
+++ b/agents/common/templates/forgot-password.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Forgot Password - Libertas</title>
+    <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
+    <link rel="stylesheet" href="/static/css/login.css">
+</head>
+<body>
+    <div class="login-container">
+        <div class="login-box">
+            <div class="login-header">
+                <i class="fas fa-feather-alt brand-icon"></i>
+                <h1>LIBERTAS</h1>
+                <p class="tagline">Reset your password</p>
+            </div>
+
+            <div class="login-error" id="fp-error">
+                <i class="fas fa-exclamation-circle"></i>
+                <span id="fp-error-message"></span>
+            </div>
+
+            <div id="fp-success" style="display:none;background:#f0fdf4;border:1px solid #86efac;border-radius:8px;padding:14px;margin-bottom:16px;color:#166534;font-size:0.9rem;">
+                <i class="fas fa-check-circle"></i>
+                If that email is registered you'll receive a reset link shortly. Check your inbox.
+            </div>
+
+            <form class="login-form" id="fp-form" novalidate>
+                <div class="form-group">
+                    <label for="fp-email">Email address</label>
+                    <input type="email" id="fp-email" name="email" required autocomplete="email" autofocus>
+                </div>
+                <button type="submit" class="login-btn" id="fp-btn">
+                    <i class="fas fa-paper-plane"></i> Send Reset Link
+                </button>
+            </form>
+
+            <div class="login-footer">
+                <p><a href="/login.html">Back to sign in</a></p>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        document.getElementById('fp-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const btn = document.getElementById('fp-btn');
+            const errDiv = document.getElementById('fp-error');
+            const errMsg = document.getElementById('fp-error-message');
+            const successDiv = document.getElementById('fp-success');
+            errDiv.style.display = 'none';
+            btn.disabled = true;
+            btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Sending...';
+
+            try {
+                const res = await fetch('/api/forgot-password', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({email: document.getElementById('fp-email').value.trim()}),
+                });
+                const data = await res.json();
+                if (data.success) {
+                    document.getElementById('fp-form').style.display = 'none';
+                    successDiv.style.display = 'block';
+                } else {
+                    errMsg.textContent = data.error || 'Something went wrong';
+                    errDiv.style.display = 'flex';
+                }
+            } catch {
+                errMsg.textContent = 'Failed to connect';
+                errDiv.style.display = 'flex';
+            }
+            btn.disabled = false;
+            btn.innerHTML = '<i class="fas fa-paper-plane"></i> Send Reset Link';
+        });
+    </script>
+</body>
+</html>

--- a/agents/common/templates/login.html
+++ b/agents/common/templates/login.html
@@ -42,6 +42,7 @@
 
             <div class="login-footer">
                 <p>Don't have an account? <a href="/register.html">Create one</a></p>
+                <p><a href="/forgot-password.html">Forgot your password?</a></p>
             </div>
         </div>
     </div>

--- a/agents/common/templates/reset-password.html
+++ b/agents/common/templates/reset-password.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reset Password - Libertas</title>
+    <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <link rel="stylesheet" href="/static/css/main.css?v=14">
+    <link rel="stylesheet" href="/static/css/login.css">
+</head>
+<body>
+    <div class="login-container">
+        <div class="login-box">
+            <div class="login-header">
+                <i class="fas fa-feather-alt brand-icon"></i>
+                <h1>LIBERTAS</h1>
+                <p class="tagline">Choose a new password</p>
+            </div>
+
+            <div class="login-error" id="rp-error" style="display:none;">
+                <i class="fas fa-exclamation-circle"></i>
+                <span id="rp-error-message"></span>
+            </div>
+
+            <div id="rp-invalid" style="display:none;background:#fef2f2;border:1px solid #fca5a5;border-radius:8px;padding:14px;margin-bottom:16px;color:#991b1b;font-size:0.9rem;">
+                <i class="fas fa-exclamation-triangle"></i>
+                This reset link is invalid or has expired. <a href="/forgot-password.html">Request a new one.</a>
+            </div>
+
+            <div id="rp-success" style="display:none;background:#f0fdf4;border:1px solid #86efac;border-radius:8px;padding:14px;margin-bottom:16px;color:#166534;font-size:0.9rem;">
+                <i class="fas fa-check-circle"></i>
+                Password updated. <a href="/login.html">Sign in</a>
+            </div>
+
+            <form class="login-form" id="rp-form" novalidate>
+                <div class="form-group">
+                    <label for="rp-new">New password</label>
+                    <input type="password" id="rp-new" required autocomplete="new-password" autofocus>
+                </div>
+                <div class="form-group">
+                    <label for="rp-confirm">Confirm new password</label>
+                    <input type="password" id="rp-confirm" required autocomplete="new-password">
+                </div>
+                <button type="submit" class="login-btn" id="rp-btn">
+                    <i class="fas fa-key"></i> Set New Password
+                </button>
+            </form>
+
+            <div class="login-footer">
+                <p><a href="/login.html">Back to sign in</a></p>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const token = new URLSearchParams(window.location.search).get('token');
+        if (!token) {
+            document.getElementById('rp-form').style.display = 'none';
+            document.getElementById('rp-invalid').style.display = 'block';
+        }
+
+        document.getElementById('rp-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const btn = document.getElementById('rp-btn');
+            const errDiv = document.getElementById('rp-error');
+            const errMsg = document.getElementById('rp-error-message');
+            errDiv.style.display = 'none';
+            btn.disabled = true;
+            btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving...';
+
+            try {
+                const res = await fetch('/api/reset-password', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({
+                        token,
+                        new_password: document.getElementById('rp-new').value,
+                        confirm_password: document.getElementById('rp-confirm').value,
+                    }),
+                });
+                const data = await res.json();
+                if (data.success) {
+                    document.getElementById('rp-form').style.display = 'none';
+                    document.getElementById('rp-success').style.display = 'block';
+                } else if (data.error && data.error.includes('expired')) {
+                    document.getElementById('rp-form').style.display = 'none';
+                    document.getElementById('rp-invalid').style.display = 'block';
+                } else {
+                    errMsg.textContent = data.error || 'Something went wrong';
+                    errDiv.style.display = 'flex';
+                }
+            } catch {
+                errMsg.textContent = 'Failed to connect';
+                errDiv.style.display = 'flex';
+            }
+            btn.disabled = false;
+            btn.innerHTML = '<i class="fas fa-key"></i> Set New Password';
+        });
+    </script>
+</body>
+</html>

--- a/agents/pages/profile_view.py
+++ b/agents/pages/profile_view.py
@@ -228,6 +228,29 @@ def generate_profile_page(profile_data: dict[str, Any]) -> str:
             </div>
         </div>
 
+        <!-- Change Password -->
+        <div class="profile-section">
+            <h2><i class="fas fa-lock"></i> Change Password</h2>
+            <div class="field-group">
+                <label>Current Password</label>
+                <input type="password" id="pw-current" autocomplete="current-password">
+            </div>
+            <div class="field-group">
+                <label>New Password</label>
+                <input type="password" id="pw-new" autocomplete="new-password">
+            </div>
+            <div class="field-group">
+                <label>Confirm New Password</label>
+                <input type="password" id="pw-confirm" autocomplete="new-password">
+            </div>
+            <div class="profile-actions">
+                <button class="btn-primary" id="change-pw-btn">
+                    <i class="fas fa-key"></i> Change Password
+                </button>
+                <span class="status-msg" id="change-pw-status"></span>
+            </div>
+        </div>
+
     </div>
 
     <script src="/static/js/main.js?v=7"></script>
@@ -315,6 +338,40 @@ def generate_profile_page(profile_data: dict[str, Any]) -> str:
             }} catch {{
                 document.getElementById('save-status').textContent = 'Failed to save';
                 document.getElementById('save-status').className = 'status-msg error';
+            }}
+            btn.disabled = false;
+        }});
+
+        document.getElementById('change-pw-btn').addEventListener('click', async () => {{
+            const btn = document.getElementById('change-pw-btn');
+            const status = document.getElementById('change-pw-status');
+            const body = {{
+                current_password: document.getElementById('pw-current').value,
+                new_password: document.getElementById('pw-new').value,
+                confirm_password: document.getElementById('pw-confirm').value,
+            }};
+            btn.disabled = true;
+            status.textContent = '';
+            try {{
+                const res = await fetch('/api/user/change-password', {{
+                    method: 'POST',
+                    headers: {{'Content-Type': 'application/json'}},
+                    body: JSON.stringify(body),
+                }});
+                const data = await res.json();
+                if (data.success) {{
+                    status.textContent = 'Password changed!';
+                    status.className = 'status-msg success';
+                    document.getElementById('pw-current').value = '';
+                    document.getElementById('pw-new').value = '';
+                    document.getElementById('pw-confirm').value = '';
+                }} else {{
+                    status.textContent = data.error || 'Failed to change password';
+                    status.className = 'status-msg error';
+                }}
+            }} catch {{
+                status.textContent = 'Failed to connect';
+                status.className = 'status-msg error';
             }}
             btn.disabled = false;
         }});

--- a/agents/pages/routes.py
+++ b/agents/pages/routes.py
@@ -10,10 +10,12 @@ import database as db
 from agents.common.flask_utils import require_auth
 from agents.common.templates import (
     generate_about_page,
+    generate_forgot_password_page,
     generate_home_page,
     generate_how_it_works_page,
     generate_login_page,
     generate_register_page,
+    generate_reset_password_page,
     get_nav_html,
 )
 from agents.explore.templates import generate_explore_page
@@ -136,6 +138,18 @@ def register():
     if g.user_id and not g.auth_disabled:
         return redirect("/")
     return _html(generate_register_page())
+
+
+@pages_bp.get("/forgot-password")
+@pages_bp.get("/forgot-password.html")
+def forgot_password():
+    return _html(generate_forgot_password_page())
+
+
+@pages_bp.get("/reset-password")
+@pages_bp.get("/reset-password.html")
+def reset_password():
+    return _html(generate_reset_password_page())
 
 
 @pages_bp.get("/profile")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fiat-lux-agents @ git+https://github.com/aabtzu/fiat-lux-agents.git
+fiat-lux-agents @ file:///Users/amitbhattacharyya/repos/fiat-lux-agents
 flask>=3.0.0
 gunicorn>=21.0.0
 airportsdata>=20240720

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fiat-lux-agents @ file:///Users/amitbhattacharyya/repos/fiat-lux-agents
+fiat-lux-agents @ git+https://github.com/aabtzu/fiat-lux-agents.git
 flask>=3.0.0
 gunicorn>=21.0.0
 airportsdata>=20240720


### PR DESCRIPTION
Integrates the fiat-lux-agents auth plugin into libertas-travel.

## Changes

- `agents/auth/routes.py` reduced to a 5-line config shim - all logic in fla-auth
- Change password section added to profile page
- Forgot password page (`/forgot-password.html`)
- Reset password page (`/reset-password.html`)
- Forgot password link on login page
- Env vars: `SENDGRID_API_KEY`, `FROM_EMAIL`, `APP_URL` (all already set on Render)

## How it works

- Forgot password: user enters email, gets a reset link valid for 1 hour
- Token is stateless HMAC-signed (no extra DB table)
- Email sent via Sendgrid
- Reset link goes to `/reset-password.html?token=...`

Closes #91