### PR TITLE
forgot-password: show real feedback (email sent or not found)

### DIFF
--- a/agents/common/templates/forgot-password.html
+++ b/agents/common/templates/forgot-password.html
@@ -25,7 +25,7 @@
 
             <div id="fp-success" style="display:none;background:#f0fdf4;border:1px solid #86efac;border-radius:8px;padding:14px;margin-bottom:16px;color:#166534;font-size:0.9rem;">
                 <i class="fas fa-check-circle"></i>
-                If that email is registered you'll receive a reset link shortly. Check your inbox.
+                Reset link sent. Check your inbox.
             </div>
 
             <form class="login-form" id="fp-form" novalidate>


### PR DESCRIPTION
- Backend (fiat-lux-agents PR #30): returns error when email not found instead of silent success\n- Frontend: shows 'Reset link sent' on success, or the actual error message on failure\n\nFixes: entering a bad email previously showed a false-positive success message.