### PR TITLE
Add PostHog analytics

### DIFF
--- a/agents/common/templates.py
+++ b/agents/common/templates.py
@@ -73,6 +73,10 @@ FOOTER_HTML = """
 
 
 NAV_HTML = """
+<script>
+!function(t,e){{var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){{function g(t,e){{var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]);t[e]=function(){{t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){{var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e}},u.people.toString=function(){{return u.toString(1)+" (stub)"}},o="init be fs capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureFlagEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset people.set people.set_once".split(" "),n=0;n<o.length;n++}}g(u,o[n]);e._i.push([i,s,a])}},e.__SV=1)}}(document,window.posthog||[]);
+posthog.init('phc_mF4crYhzpbNaoq7TBwM7C2yVVNtFUjTvWPN8LbHuuFZC',{{api_host:'https://us.i.posthog.com',person_profiles:'identified_only'}});
+</script>
 <nav class="libertas-nav">
     <a href="/" class="brand">
         <i class="fas fa-feather-alt brand-icon"></i>

--- a/agents/trips/routes.py
+++ b/agents/trips/routes.py
@@ -538,6 +538,14 @@ def fill_trip_links(link: str):
     return json_err(result.get("error", "Unknown error"), status=status)
 
 
+@trips_bp.get("/api/user/me")
+def get_current_user():
+    """Return minimal current user info for client-side analytics identification."""
+    if not g.user_id:
+        return json_ok({"user_id": None})
+    return json_ok({"user_id": g.user_id})
+
+
 @trips_bp.get("/api/user/profile")
 @require_auth
 def get_user_profile_api():

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -718,3 +718,11 @@ window.showFeedbackPopup = function (subject) {
         }
     });
 };
+
+// Identify the logged-in user to PostHog so sessions are tied to accounts.
+// Runs once per page load; posthog.identify is a no-op for anonymous users.
+fetch('/api/user/me').then(r => r.json()).then(data => {
+    if (data.user_id && window.posthog) {
+        posthog.identify(String(data.user_id));
+    }
+}).catch(() => {});


### PR DESCRIPTION
Closes #96

- PostHog JS snippet added to nav (loads on every page) - captures pageviews and session recordings automatically
- `/api/user/me` endpoint returns current user_id for client-side identification
- `main.js` calls `posthog.identify(user_id)` on every page load so sessions tie to real users
- Anonymous visitors are tracked but not identified until login