### PR TITLE
fix: preserve line breaks in tip notes

### DIFF
--- a/static/css/create-content.css
+++ b/static/css/create-content.css
@@ -92,6 +92,7 @@
     font-size: 0.85rem;
     color: #555;
     line-height: 1.5;
+    white-space: pre-wrap;
 }
 
 .tip-delete {


### PR DESCRIPTION
Added white-space: pre-wrap to .tip-text so multiline notes display with proper line breaks instead of running together.