### PR TITLE
Use stored google_maps_link in shared trip view; surface website link

### DIFF
--- a/agents/itinerary/models.py
+++ b/agents/itinerary/models.py
@@ -47,6 +47,7 @@ class ItineraryItem:
     day_number: int | None = None
     is_home_location: bool = False  # True if this is the traveler's home/origin
     website_url: str | None = None  # Direct link to hotel/activity website if available
+    google_maps_link: str | None = None  # Stored Maps URL set by fill_missing_links
 
     def to_dict(self) -> dict:
         return {
@@ -63,6 +64,7 @@ class ItineraryItem:
             "day_number": self.day_number,
             "is_home_location": self.is_home_location,
             "website_url": self.website_url,
+            "google_maps_link": self.google_maps_link,
         }
 
 

--- a/agents/itinerary/parser.py
+++ b/agents/itinerary/parser.py
@@ -310,6 +310,8 @@ class ItineraryParser:
                 notes=item_data.get("notes"),
                 day_number=item_data.get("day_number"),
                 is_home_location=item_data.get("is_home_location", False),
+                website_url=item_data.get("website_url") or item_data.get("website"),
+                google_maps_link=item_data.get("google_maps_link"),
             )
             items.append(item)
 

--- a/agents/itinerary/web_view_columns.py
+++ b/agents/itinerary/web_view_columns.py
@@ -255,12 +255,22 @@ def format_column_item(item: ItineraryItem) -> str:
             f'<div class="column-item-time"><i class="fas fa-clock"></i> {time_display}</div>'
         )
 
-    # Display location as a Google Maps link so anyone (logged in or not) can tap to navigate
+    # Display location as a Google Maps link so anyone (logged in or not) can tap to navigate.
+    # Prefer the stored google_maps_link (set by Fill Links) - it has been validated and is exact.
+    # Fall back to a constructed query only when no stored link exists.
     if show_location and short_location:
-        query = urllib.parse.quote(f"{title} {location_name}")
-        maps_url = f"https://www.google.com/maps/search/?api=1&query={query}"
+        maps_url = item.google_maps_link
+        if not maps_url:
+            query = urllib.parse.quote(f"{title} {location_name}")
+            maps_url = f"https://www.google.com/maps/search/?api=1&query={query}"
         parts.append(
-            f'<div class="column-item-location"><a href="{maps_url}" target="_blank" rel="noopener" class="column-item-maps-link"><i class="fas fa-map-marker-alt"></i> {html_module.escape(short_location)}</a></div>'
+            f'<div class="column-item-location"><a href="{html_module.escape(maps_url)}" target="_blank" rel="noopener" class="column-item-maps-link"><i class="fas fa-map-marker-alt"></i> {html_module.escape(short_location)}</a></div>'
+        )
+
+    # Show website link if available
+    if item.website_url:
+        parts.append(
+            f'<div class="column-item-website"><a href="{html_module.escape(item.website_url)}" target="_blank" rel="noopener" class="column-item-maps-link"><i class="fas fa-external-link-alt"></i> Website</a></div>'
         )
 
     # Display notes/description if present

--- a/static/css/trip.css
+++ b/static/css/trip.css
@@ -286,6 +286,13 @@
     text-decoration: underline;
 }
 
+.column-item-website {
+    display: block;
+    font-size: 0.8rem;
+    color: #888;
+    margin-top: 2px;
+}
+
 .column-item-notes {
     font-size: 0.8rem;
     color: #666;


### PR DESCRIPTION
The previous implementation constructed Maps URLs on the fly from title + location name. This is brittle - the query can match the wrong place.

Changes:
- Added google_maps_link to ItineraryItem model (it was already in the stored JSON but dropped by the parser)
- Parser now reads both website_url and google_maps_link from the stored dict
- Column view prefers the stored link when it exists, falls back to constructed query when not
- Website link shown below location when item has one