### PR TITLE
Move Maps URL logic to ItineraryItem.maps_url; fix shared trip view links

### DIFF
--- a/agents/itinerary/models.py
+++ b/agents/itinerary/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import urllib.parse
 from dataclasses import dataclass, field
 from datetime import date, time
 
@@ -48,6 +49,19 @@ class ItineraryItem:
     is_home_location: bool = False  # True if this is the traveler's home/origin
     website_url: str | None = None  # Direct link to hotel/activity website if available
     google_maps_link: str | None = None  # Stored Maps URL set by fill_missing_links
+
+    @property
+    def maps_url(self) -> str:
+        """Return a Google Maps URL for this item.
+
+        Prefers the stored google_maps_link (set by Fill Links, which is precise).
+        Falls back to a constructed search query when none is stored.
+        """
+        if self.google_maps_link:
+            return self.google_maps_link
+        loc = self.location.name if self.location else None
+        query = urllib.parse.quote(f"{self.title} {loc}" if loc else self.title)
+        return f"https://www.google.com/maps/search/?api=1&query={query}"
 
     def to_dict(self) -> dict:
         return {

--- a/agents/itinerary/web_view.py
+++ b/agents/itinerary/web_view.py
@@ -271,7 +271,7 @@ class ItineraryWebView:
             maps_url = html_module.escape(item.maps_url)
             lines.append(
                 f'<a class="activity-location" href="{maps_url}" target="_blank" rel="noopener">'
-                f'{html_module.escape(location)}</a>'
+                f"{html_module.escape(location)}</a>"
             )
         else:
             lines.append('<span class="activity-location"></span>')

--- a/agents/itinerary/web_view.py
+++ b/agents/itinerary/web_view.py
@@ -267,7 +267,14 @@ class ItineraryWebView:
 
         lines.append('<div class="activity-info">')
         lines.append(f'<span class="activity-title">{html_module.escape(title)}</span>')
-        lines.append(f'<span class="activity-location">{html_module.escape(location)}</span>')
+        if location:
+            maps_url = html_module.escape(item.maps_url)
+            lines.append(
+                f'<a class="activity-location" href="{maps_url}" target="_blank" rel="noopener">'
+                f'{html_module.escape(location)}</a>'
+            )
+        else:
+            lines.append('<span class="activity-location"></span>')
         lines.append("</div>")
         lines.append("</div>")
         return lines

--- a/agents/itinerary/web_view_columns.py
+++ b/agents/itinerary/web_view_columns.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import calendar
 import html as html_module
 import json
-import urllib.parse
 from datetime import date
 
 from agents.common.categories import CATEGORY_ICONS, TRAVEL_CATEGORIES
@@ -255,16 +254,10 @@ def format_column_item(item: ItineraryItem) -> str:
             f'<div class="column-item-time"><i class="fas fa-clock"></i> {time_display}</div>'
         )
 
-    # Display location as a Google Maps link so anyone (logged in or not) can tap to navigate.
-    # Prefer the stored google_maps_link (set by Fill Links) - it has been validated and is exact.
-    # Fall back to a constructed query only when no stored link exists.
+    # Use item.maps_url (defined on ItineraryItem) - prefers stored link, falls back to query
     if show_location and short_location:
-        maps_url = item.google_maps_link
-        if not maps_url:
-            query = urllib.parse.quote(f"{title} {location_name}")
-            maps_url = f"https://www.google.com/maps/search/?api=1&query={query}"
         parts.append(
-            f'<div class="column-item-location"><a href="{html_module.escape(maps_url)}" target="_blank" rel="noopener" class="column-item-maps-link"><i class="fas fa-map-marker-alt"></i> {html_module.escape(short_location)}</a></div>'
+            f'<div class="column-item-location"><a href="{html_module.escape(item.maps_url)}" target="_blank" rel="noopener" class="column-item-maps-link"><i class="fas fa-map-marker-alt"></i> {html_module.escape(short_location)}</a></div>'
         )
 
     # Show website link if available

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -297,6 +297,12 @@ body {
     color: #888;
     font-size: 0.85rem;
     margin-top: 2px;
+    text-decoration: none;
+}
+
+a.activity-location:hover {
+    color: #667eea;
+    text-decoration: underline;
 }
 
 /* ==================== Locations Section ==================== */


### PR DESCRIPTION
Addresses two things:

1. Shared trip .html had no Maps links at all - activity-location was a plain span
2. The Maps URL construction was duplicated between web_view.py and web_view_columns.py

Fix: add a maps_url property to ItineraryItem that is the single source of truth.
Both renderers call item.maps_url. Property prefers stored google_maps_link (set by
Fill Links) and falls back to a constructed search query.