### PR TITLE
Preserve google_maps_link through worker deserialization

### DIFF
--- a/agents/itinerary/geocoding_worker.py
+++ b/agents/itinerary/geocoding_worker.py
@@ -198,6 +198,7 @@ def deserialize_itinerary(data):
             notes=item_data.get("notes"),
             is_home_location=item_data.get("is_home_location", False),
             website_url=item_data.get("website_url"),
+            google_maps_link=item_data.get("google_maps_link"),
         )
         items.append(item)
 
@@ -358,6 +359,7 @@ def _convert_itinerary_data_to_worker_format(itinerary_data, trip_title=None):
                     "notes": item.get("notes"),
                     "is_home_location": False,
                     "website_url": item.get("website"),
+                    "google_maps_link": item.get("google_maps_link"),
                 }
             )
 
@@ -380,6 +382,7 @@ def _convert_itinerary_data_to_worker_format(itinerary_data, trip_title=None):
                 "notes": item.get("notes"),
                 "is_home_location": False,
                 "website_url": item.get("website"),
+                "google_maps_link": item.get("google_maps_link"),
             }
         )
 


### PR DESCRIPTION
Both conversion functions in geocoding_worker.py dropped google_maps_link from each itinerary item, so item.maps_url always fell through to the constructed-query fallback and the stored precise links were lost.

This is the third place the same field needed threading through - the other two (parser.py and the ItineraryItem model) were fixed in PR #105.