### PR TITLE
Make activity-location links visually obvious

### DIFF
--- a/agents/itinerary/web_view.py
+++ b/agents/itinerary/web_view.py
@@ -271,6 +271,7 @@ class ItineraryWebView:
             maps_url = html_module.escape(item.maps_url)
             lines.append(
                 f'<a class="activity-location" href="{maps_url}" target="_blank" rel="noopener">'
+                f'<i class="fas fa-map-marker-alt" style="font-size:0.75rem;margin-right:3px;"></i>'
                 f"{html_module.escape(location)}</a>"
             )
         else:

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -294,14 +294,14 @@ body {
 
 .activity-location {
     display: block;
-    color: #888;
+    color: #667eea;
     font-size: 0.85rem;
     margin-top: 2px;
     text-decoration: none;
 }
 
 a.activity-location:hover {
-    color: #667eea;
+    color: #5a6fd6;
     text-decoration: underline;
 }
 


### PR DESCRIPTION
The Maps links existed in the HTML but were #888 grey with text-decoration:none, indistinguishable from plain text. Changed to #667eea accent color and added a fa-map-marker-alt icon.