### PR TITLE
Add inline Website + Map links to full itinerary list view

### DIFF
--- a/agents/itinerary/web_view.py
+++ b/agents/itinerary/web_view.py
@@ -276,6 +276,18 @@ class ItineraryWebView:
             )
         else:
             lines.append('<span class="activity-location"></span>')
+        # Inline Website + Map links, same as the recommendation view
+        item_links = ""
+        if item.website_url:
+            item_links += (
+                f'<a class="activity-inline-link" href="{html_module.escape(item.website_url)}"'
+                f' target="_blank" rel="noopener"><i class="fas fa-globe"></i> Website</a>'
+            )
+        item_links += (
+            f'<a class="activity-inline-link" href="{html_module.escape(item.maps_url)}"'
+            f' target="_blank" rel="noopener"><i class="fas fa-map"></i> Map</a>'
+        )
+        lines.append(f'<div class="activity-links">{item_links}</div>')
         lines.append("</div>")
         lines.append("</div>")
         return lines

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -305,6 +305,25 @@ a.activity-location:hover {
     text-decoration: underline;
 }
 
+.activity-links {
+    display: flex;
+    gap: 16px;
+    margin-top: 4px;
+}
+
+.activity-inline-link {
+    color: #667eea;
+    text-decoration: none;
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.activity-inline-link:hover {
+    text-decoration: underline;
+}
+
 /* ==================== Locations Section ==================== */
 .locations-section {
     margin-top: 30px;


### PR DESCRIPTION
Matches the recommendation view behavior: each activity now shows Website and Map links inline below the item, not just in the popup. Map link always present; Website only when the item has one.