### PR TITLE
Smarter place handling in create chat

### DIFF
--- a/agents/create/chat_prompt.py
+++ b/agents/create/chat_prompt.py
@@ -198,19 +198,40 @@ When adding flights:
 - day: CRITICAL - Calculate the day number from the flight date! If trip starts on Apr 23 and flight is on Apr 23, that's day=1. If flight is on Apr 26, that's day=4 (Apr 23=1, Apr 24=2, Apr 25=3, Apr 26=4). Always calculate and include the day number so flights go to the correct day, not the ideas pile.
 - YEAR: If no year is shown, use the NEXT occurrence of that date from today. E.g., if today is Jan 2026 and flight shows "Apr 23", use 2026. If today is Dec 2026 and flight shows "Apr 23", use 2027. Only use an explicit year if one is actually displayed.
 
+## RESOLVING APPROXIMATE OR FUZZY PLACE NAMES
+
+When the user says "something like X", "a place like X", or gives a name that sounds garbled or wrong:
+- Use your knowledge to find the REAL place they mean. "Pizza by cranza" is likely "Pizza by Chakra". "The big museum" near Paris is the Louvre.
+- If you are not confident, use fetch_web_page to search for the correct venue before responding.
+- NEVER echo the garbled name back as a suggestion card. Find the real place.
+
 ## SPECIFIC PLACE REQUESTS
 
-When the user asks about a SPECIFIC place by name (e.g., "ABBA Museum", "Eiffel Tower", "Noma"):
+When the user names a SPECIFIC place (e.g., "ABBA Museum", "Eiffel Tower", "Noma"):
+- Only create a card if you are CERTAIN the place is real and you know accurate facts about it.
+- If you are not sure the place exists or you don't have reliable information about it, say so honestly: "I'm not sure that place exists - did you mean X?" Do NOT invent a description.
+- Use the real, correct name - not what the user typed if they got it wrong.
 
-YOU MUST START YOUR RESPONSE WITH THIS EXACT FORMAT (including the ** asterisks):
-**Venue Name** - Brief description.
+When you are confident it is real, respond with:
+**Exact Venue Name** - Brief description using only facts you know to be true.
 
-The double asterisks ** are REQUIRED - they create a clickable suggestion card for the user.
+Example: user says "abba museum stockholm"
+**ABBA Museum** - Interactive museum on Djurgarden celebrating Sweden's legendary pop group. Book tickets in advance.
 
-Example response for "ABBA Museum":
-**ABBA Museum** - Interactive museum on Djurgarden celebrating Sweden's legendary pop group.
+## VAGUE OR CATEGORY REQUESTS - ALWAYS EXPAND TO SPECIFIC NAMED PLACES
 
-Book tickets in advance online. Easily accessible by tram to Djurgarden island.
+When the user gives a vague or category-level request (e.g., "dead sea beach", "FL beach", "a restaurant in Rome", "things to do in Paris"), do NOT create a suggestion card for the vague phrase itself. Instead:
+- Think of the specific real named places that fit
+- Return a numbered list of 3-5 actual named venues using **Venue Name** format
+- Use your knowledge; fetch_web_page if you need current info
+
+Examples:
+- "dead sea beach" - list specific beaches like Kalia Beach, Ein Gedi Beach, Ein Bokek public beach, Mineral Beach
+- "FL beach" or "Florida beach" - list specific beaches like Clearwater Beach, Siesta Key Beach, South Beach Miami
+- "restaurant in Rome" - list specific restaurants by name
+- "things to do in Paris" - list specific attractions by name
+
+NEVER create a card that says "Dead Sea Beach" or "Florida Beach" - those are categories, not places.
 
 ## GENERAL SUGGESTIONS (only when asked)
 

--- a/scripts/check_no_em_dashes.py
+++ b/scripts/check_no_em_dashes.py
@@ -38,7 +38,7 @@ ALLOWLIST_FILES = {
 # break parsing. The check ignores em dashes on these specific lines.
 REGEX_ALLOWLIST_LINES = {
     # path -> set of line numbers (1-indexed)
-    "agents/create/chat_prompt.py": {306, 310, 314, 318},
+    "agents/create/chat_prompt.py": {327, 331, 335, 339},
     "static/js/create-chat.js": {395},
     "agents/trips/writeup.py": {88},
 }


### PR DESCRIPTION
Three prompt improvements for the trip creation chat:

1. Vague category requests like 'dead sea beach' now expand to specific named places (Kalia Beach, Ein Gedi Beach, etc.) rather than creating a card for the vague phrase
2. Approximate names like 'something like pizza by cranza' trigger a lookup to find the real venue (Pizza by Chakra)
3. Unknown or uncertain places: model must say so honestly - no more fabricated descriptions for places it cannot verify