### PR TITLE
Fix grid view scroll in mobile landscape

### DIFF
--- a/static/css/main-mobile-modal.css
+++ b/static/css/main-mobile-modal.css
@@ -93,6 +93,29 @@
         padding: 5px 10px;
         font-size: 0.8rem;
     }
+
+    /* Grid/column view: remove the fixed max-height so the page scrolls
+       instead of a tiny box inside an already short viewport */
+    .column-table-wrapper {
+        max-height: none;
+        overflow-y: visible;
+    }
+
+    /* Shrink column table text so more fits horizontally */
+    .column-table th,
+    .column-table td {
+        padding: 6px 8px;
+        font-size: 0.8rem;
+    }
+
+    .column-item {
+        padding: 8px;
+        margin-bottom: 10px;
+    }
+
+    .column-item-title {
+        font-size: 0.85rem;
+    }
 }
 
 /* ==================== Shared Mobile Components ==================== */


### PR DESCRIPTION
Column table wrapper had max-height: 80vh which on a landscape phone leaves almost nothing to scroll. In the landscape media query, remove the cap so the page scrolls instead of a tiny fixed-height box.