### PR TITLE
Hide ideas pile on grid/map/calendar tabs

### DIFF
--- a/agents/create/templates/create.html
+++ b/agents/create/templates/create.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/categories.css">
     <link rel="stylesheet" href="/static/css/create.css?v=22">
-    <link rel="stylesheet" href="/static/css/create-content.css?v=5">
+    <link rel="stylesheet" href="/static/css/create-content.css?v=6">
     <link rel="stylesheet" href="/static/css/create-chat.css?v=1">
     <link rel="stylesheet" href="/static/css/create-views.css?v=2">
 </head>
@@ -374,7 +374,7 @@
     <script src="/static/js/create-save.js?v=4"></script>
     <script src="/static/js/create-chat.js?v=6"></script>
     <script src="/static/js/create-dragdrop.js?v=2"></script>
-    <script src="/static/js/create-grid.js?v=4"></script>
+    <script src="/static/js/create-grid.js?v=5"></script>
     <script src="/static/js/create-map.js?v=3"></script>
 
     <!-- Mobile floating chat button - must be direct child of body for position:fixed -->

--- a/static/css/create-content.css
+++ b/static/css/create-content.css
@@ -1,6 +1,12 @@
 /* Create Trip Page, Ideas pile, tips, write-up, upload indicator (split from create.css) */
 
 /* ==================== Ideas Pile ==================== */
+
+/* Hide the ideas pile when grid/map/calendar tab is active - only relevant on itinerary view */
+.tab-no-ideas .ideas-pile {
+    display: none;
+}
+
 .ideas-pile {
     background: white;
     border-radius: 12px;

--- a/static/js/create-grid.js
+++ b/static/js/create-grid.js
@@ -14,6 +14,12 @@ function switchTimelineTab(tabName) {
         content.classList.toggle('active', content.id === tabName + '-tab');
     });
 
+    // Hide the ideas pile when on grid/map/calendar - it's only useful on itinerary view
+    const timeline = document.querySelector('.editor-timeline');
+    if (timeline) {
+        timeline.classList.toggle('tab-no-ideas', tabName !== 'itinerary');
+    }
+
     // Initialize map when switching to map tab
     if (tabName === 'map') {
         updateMapDaySelector();


### PR DESCRIPTION
The ideas pile only matters on the itinerary tab where items can be dragged into days. On grid, map, and calendar views it was just consuming vertical space - particularly painful on small/landscape viewports.

**Change:** `switchTimelineTab` now adds `tab-no-ideas` to `.editor-timeline` when switching to any non-itinerary tab. CSS hides `.ideas-pile` when that class is present. Reverts automatically when switching back to itinerary tab.

Fixes the landscape mobile layout issue where the ideas pile was pinned at the bottom taking up too much space.