### PR TITLE
Grid tab: page scrolls instead of fixed-height inner box

### DIFF
--- a/agents/create/templates/create.html
+++ b/agents/create/templates/create.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/static/css/main.css?v=14">
     <link rel="stylesheet" href="/static/css/main-mobile-modal.css?v=1">
     <link rel="stylesheet" href="/static/css/categories.css">
-    <link rel="stylesheet" href="/static/css/create.css?v=22">
+    <link rel="stylesheet" href="/static/css/create.css?v=23">
     <link rel="stylesheet" href="/static/css/create-content.css?v=6">
     <link rel="stylesheet" href="/static/css/create-chat.css?v=1">
     <link rel="stylesheet" href="/static/css/create-views.css?v=2">
@@ -374,7 +374,7 @@
     <script src="/static/js/create-save.js?v=4"></script>
     <script src="/static/js/create-chat.js?v=6"></script>
     <script src="/static/js/create-dragdrop.js?v=2"></script>
-    <script src="/static/js/create-grid.js?v=5"></script>
+    <script src="/static/js/create-grid.js?v=6"></script>
     <script src="/static/js/create-map.js?v=3"></script>
 
     <!-- Mobile floating chat button - must be direct child of body for position:fixed -->

--- a/static/css/create.css
+++ b/static/css/create.css
@@ -241,6 +241,22 @@
     background: #f5f5f5;
 }
 
+/* Grid/calendar/map tabs: let the page scroll naturally instead of boxing
+   the content in a fixed-height scroll area. The sidebar stays put via its
+   own fixed positioning on mobile and its own overflow-y on desktop. */
+.create-container.timeline-scrolls {
+    height: auto;
+    min-height: calc(100vh - 60px);
+}
+
+.create-container.timeline-scrolls .editor-main {
+    overflow: visible;
+}
+
+.create-container.timeline-scrolls .editor-timeline {
+    overflow-y: visible;
+}
+
 /* ==================== Editor Header ==================== */
 .editor-header {
     display: flex;

--- a/static/js/create-grid.js
+++ b/static/js/create-grid.js
@@ -20,6 +20,12 @@ function switchTimelineTab(tabName) {
         timeline.classList.toggle('tab-no-ideas', tabName !== 'itinerary');
     }
 
+    // Let the page scroll naturally on grid/map/calendar; restore fixed height on itinerary
+    const container = document.querySelector('.create-container');
+    if (container) {
+        container.classList.toggle('timeline-scrolls', tabName !== 'itinerary');
+    }
+
     // Initialize map when switching to map tab
     if (tabName === 'map') {
         updateMapDaySelector();


### PR DESCRIPTION
The grid was trapped in a fixed-height scroll box because `.editor-main` has `overflow: hidden` and `.editor-timeline` has `overflow-y: auto`. Small/medium viewports only showed a couple of rows before hitting the box edge.

**Fix:** `switchTimelineTab` now adds `.timeline-scrolls` to `.create-container` when switching to grid/map/calendar. That class removes the fixed height and switches overflow to visible so the page body scrolls naturally. Switching back to itinerary restores the original layout (needed for the chat sidebar).