### PR TITLE
Remove max-height scroll box from grid tab

### DIFF
--- a/agents/create/templates/create.html
+++ b/agents/create/templates/create.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="/static/css/create.css?v=23">
     <link rel="stylesheet" href="/static/css/create-content.css?v=6">
     <link rel="stylesheet" href="/static/css/create-chat.css?v=1">
-    <link rel="stylesheet" href="/static/css/create-views.css?v=2">
+    <link rel="stylesheet" href="/static/css/create-views.css?v=3">
 </head>
 <body>
     {nav_html}

--- a/static/css/create-views.css
+++ b/static/css/create-views.css
@@ -161,8 +161,8 @@
 /* ==================== Column Table View (Grid Tab) ==================== */
 .column-table-wrapper {
     width: 100%;
-    max-height: calc(100vh - 250px);
-    overflow-y: auto;
+    /* No max-height: the table grows to full content height and the page scrolls.
+       Capping it creates a tiny nested scroll box which is worse on mobile. */
     overflow-x: auto;
     border-radius: 8px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);


### PR DESCRIPTION
The grid wrapper in create-views.css had `max-height: calc(100vh - 250px)` with `overflow-y: auto`, which created a small nested scroll box. The column headers were sticky inside that box, giving the appearance of frozen headers in a cramped table.

Removing the cap lets the table grow to full content height and the page body scrolls naturally. The sticky thead still works correctly - without an overflow ancestor it sticks to the page scroll container.