### PR TITLE
Allow horizontal scroll in grid tab on portrait mobile

### DIFF
--- a/agents/create/templates/create.html
+++ b/agents/create/templates/create.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="/static/css/categories.css">
     <link rel="stylesheet" href="/static/css/create.css?v=23">
     <link rel="stylesheet" href="/static/css/create-content.css?v=6">
-    <link rel="stylesheet" href="/static/css/create-chat.css?v=1">
+    <link rel="stylesheet" href="/static/css/create-chat.css?v=2">
     <link rel="stylesheet" href="/static/css/create-views.css?v=3">
 </head>
 <body>

--- a/static/css/create-chat.css
+++ b/static/css/create-chat.css
@@ -424,12 +424,6 @@
 
 /* ==================== Responsive ==================== */
 @media (max-width: 900px) {
-    /* Prevent horizontal scroll on mobile */
-    html, body {
-        overflow-x: hidden;
-        max-width: 100vw;
-    }
-
     /* Hide sidebar by default on mobile */
     .editor-sidebar {
         position: fixed;


### PR DESCRIPTION
The mobile media query had `html, body { overflow-x: hidden }` to prevent incidental layout overflow. This also blocked intentional horizontal scroll on the grid table, which needs `min-width: 800px` to display all columns.

The chat sidebar uses `position: fixed; right: -100%` so it never affects document flow - the body clamp was not needed for it.